### PR TITLE
Added lektro-kaufen[dot]com

### DIFF
--- a/notserious
+++ b/notserious
@@ -4544,7 +4544,7 @@ meine-goldscheideanstalt.de
 sigma-tech.store
 media-deals24.de
 
-
+lektro-kaufen.com
 
 
 


### PR DESCRIPTION
From another's YouTube comment.
from 0nlyJ2W around 13:00
"https://lektro-kaufen.com/ ist auch eine Betrugswebsite. Rein zufällig sind alle Artikel reduziert, nur Vorkasse und Impressum ist auch frei erfunden."