### PR TITLE
Fehler in der Hardware Liste behoben

### DIFF
--- a/Benötigte Hardware.md
+++ b/Benötigte Hardware.md
@@ -16,7 +16,7 @@ Sie wollen ein Pi-hole für Ihr Netzwerk? Nichts einfacher als das. Nachfolgend 
 <tr>
   <td><b>Low-Buget-Variante:</b><td>
 <tr><td>https://amzn.to/2XJh8O6 <td>Raspberry Pi 3 Model B 1GB
-<tr><td>https://amzn.to/2DsOrf7 <td>3A Netzteil Type-C USB Kabel Stecker Ladegerät
+<tr><td>https://amzn.to/34rvHIs <td>5V 3A Netzteil Raspberry Pi 3 Model B B+ Und Geräte mit Micro USB Port
 <tr><td>https://amzn.to/2XLeQxS <td>Gehäuse für Raspberry Pi 3 ****
 <tr><td>https://amzn.to/2KSwQRR <td>SanDisk Ultra 16GB microSDHC***
 <tr><td>https://amzn.to/2OigiET <td>SD/Micro SD Kartenleser Speicherkartenleser mit Micro USB 


### PR DESCRIPTION
Ein USB-C Netzteil lässt sich nicht mit dem Raspberry Pi 3 verwenden, ich habe daher ein passendes Modell herausgesucht und eingetragen.