### PR TITLE
Update Blocklisten.md

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -38,5 +38,4 @@ Andere nützliche Listen:
 * https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
 
 # Divers
-* https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist
 * https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts


### PR DESCRIPTION
Liste wurde eingestellt, folgt man den Link erscheint die Meldung 

# ZeuS Tracker has been discontinued on Jul 8th, 2019
