### PR TITLE
Wildcards entfernen

### DIFF
--- a/regex.list
+++ b/regex.list
@@ -1,8 +1,8 @@
 Sperrt alle Domains aus China:
-([a-zA-Z0-9-\.]{2,256})(.cn)
+([a-zA-Z0-9-\.]{2,256})(\.cn)
 
 Sperrt alle URLs zu "sendgrid.net"
-([a-zA-Z0-9-\.]{0,256})(sendgrid)(.net)
+([a-zA-Z0-9-\.]{0,256})(sendgrid)(\.net)
 
 Sperrt alle Punycode-Domains:
 .*(xn--)([a-zA-Z0-9-\.]{2,256})*(\.[a-z]{2,6})


### PR DESCRIPTION
(.net) bedeutet dass jedes Zeichen (den Punkt mit eingeschlossen) sich dort befinden kann.
(\\.net) definiert dass sich dort NUR der Punkt befinden darf.