### PR TITLE
Update whitelist

### DIFF
--- a/whitelist
+++ b/whitelist
@@ -55,4 +55,5 @@ amzn.to
 amzn.com
 google.de
 www.google.de
-
+amazon.com
+www.amazon.com


### PR DESCRIPTION
Amazon.com is currently contained in the blocklist Phinsing-Angriffe.