### PR TITLE
Add github and a few oss projects to whitelist

### DIFF
--- a/whitelist
+++ b/whitelist
@@ -65,3 +65,12 @@ outlook.office365.com
 facebook.com
 www.facebook.com
 login.live.com
+github.com
+teeworlds.com
+www.teeworlds.com
+blender.org
+www.blender.org
+obsproject.com
+vim.org
+www.vim.org
+git.kernel.org


### PR DESCRIPTION
All the urls added in this pr are official sites of legit community driven open source projects with github.com being the exception but since this whitelist is hosted on github it also makes sense to whitelist github.