### PR TITLE
whitelist: Added public search engines

### DIFF
--- a/whitelist
+++ b/whitelist
@@ -74,3 +74,15 @@ obsproject.com
 vim.org
 www.vim.org
 git.kernel.org
+ddg.gg
+duckduckgo.com
+www.duckduckgo.com
+start.duckduckgo.com
+startpage.com
+www.startpage.com
+bing.com
+www.bing.com
+ecosia.org
+www.ecosia.org
+metager.de
+www.metager.de


### PR DESCRIPTION
To prevent users from being "locked out" of the internet