### PR TITLE
Update whitelist to include Deutsche Telekom

### DIFF
--- a/whitelist
+++ b/whitelist
@@ -74,3 +74,8 @@ obsproject.com
 vim.org
 www.vim.org
 git.kernel.org
+accounts.login.idm.telekom.com
+login.idm.telekom.com
+telekom.com
+www.telekom.com
+kundencenter.telekom.de


### PR DESCRIPTION
To allow access to the website of Deutsche Telekom and the Kundencenter of Deutsche Telekom.