### PR TITLE
Add condition for updating root servers hint file

### DIFF
--- a/Unbound.md
+++ b/Unbound.md
@@ -11,11 +11,12 @@ nano /root/updateroot
 
 Folgenden Inhalt einfügen:
 ```
-#!/bin/sh
-wget -O root.hints https://www.internic.net/domain/named.root
-rm /var/lib/unbound/root.hints
-mv root.hints /var/lib/unbound/
-service unbound restart
+#!/bin/bash
+
+if wget -O /tmp/root.hints https://www.internic.net/domain/named.root ; then
+    mv /tmp/root.hints /var/lib/unbound/root.hints
+    systemctl restart unbound
+fi
 ```
 
 Die Datei ausführbar machen:


### PR DESCRIPTION
Add condition for only replacing the root.hints file if the download was successful, so starting the unbound server with a corrupted hints file will be prevented.