### PR TITLE
removed false-positives and duplicates

### DIFF
--- a/Blocklisten/jugendschutz
+++ b/Blocklisten/jugendschutz
@@ -361,7 +361,6 @@ mankind.org
 masada2000.org
 maso.roumen.cz
 massresistance.org
-mediafire.com
 medievality.com
 melvig.org
 members.ozemail.com.au

--- a/whitelist
+++ b/whitelist
@@ -35,7 +35,6 @@ spclient.wg.spotify.com
 apresolve.spotify.com
 itunes.apple.com
 s.mzstatic.com
-android.clients.google.com
 appspot-preview.l.google.com
 prod.telemetry.ros.rockstargames.com
 tracking.epicgames.com
@@ -46,10 +45,8 @@ secure.netflix.com
 time.samsungcloudsolution.com
 cdn.samsungcloudsolution.com
 mobile-ap.spotify.com
-apresolve.spotify.com
 upgrade.scdn.com
 market.spotify.com
-spclient.wg.spotify.com
 audio-ake.spotify.com.edgesuite.net
 amzn.to
 amzn.com


### PR DESCRIPTION
removed mediafire.com (filehoster) from jugendschutz
removed onedrive.live.com (OneDrive) from Phishing-Angriffe
checked and removed duplicates from whitelist