### PR TITLE
Liste um „Qualitätsfernsehen“ zu blockieren

### DIFF
--- a/Blocklisten/qualitaetsfernsehen
+++ b/Blocklisten/qualitaetsfernsehen
@@ -2,6 +2,10 @@
 
 rtl.de
 www.rtl.de
+rtl.at
+www.rtl.at
+rtl.ch
+www.rtl.ch
 
 sat1.de
 www.sat1.de
@@ -14,18 +18,28 @@ pro7.de
 www.pro7.de
 prosieben.de
 www.prosieben.de
+prosieben.at
+www.prosieben.at
+prosieben.ch
+www.prosieben.ch
 
 vox.de
 www.vox.de
 
 sat1gold.de
 www.sat1gold.de
+sat1gold.at
+www.sat1gold.at
 
 prosiebenmaxx.de
 www.prosiebenmaxx.de
 
 rtl2.de
 www.rtl2.de
+rtl2.at
+www.rtl2.at
+rtl2.ch
+www.rtl2.ch
 
 rtlnitro.de
 www.rtlnitro.de
@@ -39,7 +53,29 @@ www.rtl-living.de
 toggo.de
 www.toggo.de
 
+rtlplus.de
+www.rtlplus.de
+rtlplus.at
+www.rtlplus.de
+
 kabeleins.de
 www.kabeleins.de
+kabeleins.at
+www.kabeleins.at
+kabeleins.ch
+www.kabeleins.ch
+kabeleinsdoku.de
+www.kabeleinsdoku.de
+kabeleinsdoku.at
+kabeleinsclassics.de
+www.kabeleinsclassics.de
+www.kabeleinsdoku.at
+
+
+astrotv.de
+www.astrotv.de
+
+eurosport.com
+www.eurosport.com
 
 berufe.tv

--- a/Blocklisten/qualitaetsfernsehen
+++ b/Blocklisten/qualitaetsfernsehen
@@ -1,0 +1,1 @@
+# Blockiert RTL, Sat1 und co.

--- a/Blocklisten/qualitaetsfernsehen
+++ b/Blocklisten/qualitaetsfernsehen
@@ -5,6 +5,10 @@ www.rtl.de
 
 sat1.de
 www.sat1.de
+sat1.at
+www.sat1.at
+sat1.ch
+www.sat1.ch
 
 pro7.de
 www.pro7.de
@@ -34,5 +38,8 @@ www.rtl-living.de
 
 toggo.de
 www.toggo.de
+
+kabeleins.de
+www.kabeleins.de
 
 berufe.tv

--- a/Blocklisten/qualitaetsfernsehen
+++ b/Blocklisten/qualitaetsfernsehen
@@ -19,3 +19,9 @@ www.sat1gold.de
 
 prosiebenmaxx.de
 www.prosiebenmaxx.de
+
+rtl2.de
+www.rtl2.de
+
+rtlnitro.de
+www.rtlnitro.de

--- a/Blocklisten/qualitaetsfernsehen
+++ b/Blocklisten/qualitaetsfernsehen
@@ -25,3 +25,14 @@ www.rtl2.de
 
 rtlnitro.de
 www.rtlnitro.de
+
+superrtl.de
+www.superrtl.de
+
+rtl-living.de
+www.rtl-living.de
+
+toggo.de
+www.toggo.de
+
+berufe.tv

--- a/Blocklisten/qualitaetsfernsehen
+++ b/Blocklisten/qualitaetsfernsehen
@@ -13,6 +13,10 @@ sat1.at
 www.sat1.at
 sat1.ch
 www.sat1.ch
+sat1gold.de
+www.sat1gold.de
+sat1gold.at
+www.sat1gold.at
 
 pro7.de
 www.pro7.de
@@ -22,17 +26,11 @@ prosieben.at
 www.prosieben.at
 prosieben.ch
 www.prosieben.ch
+prosiebenmaxx.de
+www.prosiebenmaxx.de
 
 vox.de
 www.vox.de
-
-sat1gold.de
-www.sat1gold.de
-sat1gold.at
-www.sat1gold.at
-
-prosiebenmaxx.de
-www.prosiebenmaxx.de
 
 rtl2.de
 www.rtl2.de
@@ -71,7 +69,6 @@ kabeleinsclassics.de
 www.kabeleinsclassics.de
 www.kabeleinsdoku.at
 
-
 astrotv.de
 www.astrotv.de
 
@@ -79,3 +76,4 @@ eurosport.com
 www.eurosport.com
 
 berufe.tv
+www.berufe.tv

--- a/Blocklisten/qualitaetsfernsehen
+++ b/Blocklisten/qualitaetsfernsehen
@@ -1,1 +1,21 @@
 # Blockiert RTL, Sat1 und co.
+
+rtl.de
+www.rtl.de
+
+sat1.de
+www.sat1.de
+
+pro7.de
+www.pro7.de
+prosieben.de
+www.prosieben.de
+
+vox.de
+www.vox.de
+
+sat1gold.de
+www.sat1gold.de
+
+prosiebenmaxx.de
+www.prosiebenmaxx.de

--- a/Blocklisten/readme.md
+++ b/Blocklisten/readme.md
@@ -14,3 +14,4 @@ Erläuterung der einzelnen Blocklisten:
 * Samsung: Domains von Samsung Tracking Diensten.
 * Spam.Mails: Domains, die über eMail verteilt werden (Phishing)
 * Pornblock1-4: Webseiten, die für Minderjährige nicht geeignet sind.
+* Qualitaetsfernsehen: Blockiert RTL, Sat1 und co.


### PR DESCRIPTION
Diese Liste blockiert einige „Qualitätsfernsehsender“ (z.B.: Rtl, Sat1 und Co.).

Name ist ironisch gemeint.