### PR TITLE
Update Google-Werbung

### DIFF
--- a/regex.list
+++ b/regex.list
@@ -30,6 +30,9 @@ Sperrt alle Punycode-Domains:
 
 Sperrt Google-Werbung:
 doubleclick\.net
+googletagmanger\.com
+google-analytics\.com
+googleadservices.\.com
 
 Sperrt alle Domains in Zusammenhang mit Instagram:
 instagram\.com


### PR DESCRIPTION
Drei weitere Regex-Einträge zum blocken von Google Werbung hinzugefügt.