### PR TITLE
Plex und WoT/WoWs URLs

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -619,3 +619,16 @@ zhihu.com
 zillow.com
 zoho.com
 zoom.us
+
+#World of Tanks und World of Warships URLs die für das Spiel benötigt werden
+api.worldoftanks.ru
+armory-wows-global.gcdn.co
+frm-wows-eu.wgcdn.co
+frm-wows-us.wgcdn.co
+glossary-wows-global.gcdn.co
+wgus-wowspt.worldofwarships.ru
+wowsp-wows-eu.wgcdn.co
+
+#Plex URLs
+app.plex.tv
+dashboard.plex.tv


### PR DESCRIPTION
Habe Urls ergänzt, damit Plex und WoT/ WoWs (https://worldoftanks.eu) funtionieren. Der Hersteller sitzt in Russland und nutzt russische Domains.