### PR TITLE
theatlantic.com

### DIFF
--- a/Blocklisten/jugendschutz
+++ b/Blocklisten/jugendschutz
@@ -1239,7 +1239,6 @@ texaskkk.com
 thatsphucked.com
 thc.com
 thc-ministry.net
-theatlantic.com
 thedea.org
 thedrugsindex.org
 thefane.org
@@ -2390,7 +2389,6 @@ www.texaskkk.com
 www.thatsphucked.com
 www.thc.com
 www.thc-ministry.net
-www.theatlantic.com
 www.thedea.org
 www.thedrugsindex.org
 www.thefane.org


### PR DESCRIPTION
Warum ist die Newsseite auf dieser Liste?
Vielleicht sollte diese auch auf die whitelist aufgenommen werden.