### PR TITLE
neue Blocklist

### DIFF
--- a/Blocklisten/brave
+++ b/Blocklisten/brave
@@ -1,0 +1,8 @@
+# Lead me to your Pihole
+# --------------------------------------------
+# Brave Blocklist
+# 
+# Quelle: https://github.com/brave/adblock-lists
+#
+# ------------------------------------------
+#


### PR DESCRIPTION
Habe den Artikel hier gelesen: https://brave.com/the-mounting-cost-of-stale-ad-blocking-rules/ und schlage vor eine neue Blocklist zu erstellen, die weniger false-positives hat als die DuckDuckGo Liste.
Hier der Link zu deren Github-Repo:
https://github.com/brave/adblock-lists