### PR TITLE
bitbucket.org

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1,4 +1,6 @@
 
+bitbucket.org
+www.bitbucket.org
 3c.tmall.com
 9gag.com
 abs-cbn.com


### PR DESCRIPTION
bitbucket.org hinzugefügt, taucht z.Z in der Malware Blacklist auf.