### PR TITLE
Entfernung: ris.bka.gv.at in 'jugenschutz'

### DIFF
--- a/Blocklisten/jugendschutz
+++ b/Blocklisten/jugendschutz
@@ -1072,7 +1072,6 @@ revisionists.com
 rhodium.ws
 ridgwaydb.mobot.org
 rightscientology.com
-ris.bka.gv.at
 riversofgore.com
 roble.net
 rollitup.org


### PR DESCRIPTION
ris.bka.gv.at ist die Adresse des Rechtsinformationssystem (RIS) von Österreich.