### PR TITLE
resolves #200

### DIFF
--- a/Blocklisten/Corona-Blocklist
+++ b/Blocklisten/Corona-Blocklist
@@ -3157,7 +3157,6 @@ californiacoronaviruscleaners.com
 californiacoronaviruslaw.com
 californiacoronaviruslawsuit.com
 californiacoronaviruslawyer.com
-californiacoronavirus.org
 californiacoronaviruspro.com
 californiacoronaviruspro.ws
 californiacoronavirusunemployment.org
@@ -19460,7 +19459,6 @@ coronavirusdatabreach.com
 corona-virus-data.com
 corona-virusdata.com
 coronavirusdata.live
-coronavirusdatamap.com
 coronavirusdatamap.org
 coronavirus-data.net
 coronavirusdata.net


### PR DESCRIPTION
- removes californiacoronavirus.org
- removes coronavirusdatamap.com