### PR TITLE
Entfernung: www.willhaben.at (notserious)

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -21619,7 +21619,6 @@ www.wildsabine.de
 www.wildstaronlinepowerguide.com
 www.willaschek-hausundhof.de
 www.willert-textildruck.de
-www.willhaben.at
 www.williesvacationrentals.com
 www.willispub.de
 www.willkommenimsueden.de


### PR DESCRIPTION
www.willhaben.at ist das eBay-Kleinanzeigen für Österreich.
Außerdem ist willhaben.at (ohne www) auch entfernt worden.