### PR TITLE
Blocklist hosts-file.net/ad_servers.txt entfernt

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -62,7 +62,6 @@ Andere nützliche Listen:
 # Werbung
 * https://v.firebog.net/hosts/Prigent-Ads.txt
 * https://v.firebog.net/hosts/AdguardDNS.txt
-* https://hosts-file.net/ad_servers.txt
 * https://adaway.org/hosts.txt
 
 # Diverses


### PR DESCRIPTION
Die Domain [https://hosts-file.net/ad_servers.txt](https://hosts-file.net/ad_servers.txt) wurde aus der Blocklisten.md entfernt, da diese Domain jetzt zu einer anderen Seite führt, auf welcher die Blocklist nicht mehr verfügbar ist.
Siehe hierzu auch [https://www.reddit.com/r/pihole/comments/fvqaad/hostsfilenet_ad_serverstxt_download_not_availabe/](https://www.reddit.com/r/pihole/comments/fvqaad/hostsfilenet_ad_serverstxt_download_not_availabe/)