### PR TITLE
i0.wp.com hinzugefügt

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1,3 +1,4 @@
+i0.wp.com
 blogger.com
 www.blogger.com
 californiacoronavirus.org


### PR DESCRIPTION
https://9to5mac.com/ lädt keine Bilder, wenn die Seite geblockt ist.