### PR TITLE
v10.vortex-win.data.microsoft.com entfernt

### DIFF
--- a/Internet Services/XBOX
+++ b/Internet Services/XBOX
@@ -54,7 +54,6 @@ userpresence.xboxlive.com
 userstats.xboxlive.com
 usertitles.xboxlive.com
 v10.events.data.microsoft.com
-v10.vortex-win.data.microsoft.com
 v20.events.data.microsoft.com
 www.msftconnecttest.com
 www.msftncsi.com


### PR DESCRIPTION
Wird nicht mehr zwingend benötigt und ist vom BSI als Trackingdomain deklariert.