### PR TITLE
Removes www.w3.org

### DIFF
--- a/Blocklisten/Phishing-Angriffe
+++ b/Blocklisten/Phishing-Angriffe
@@ -35764,7 +35764,6 @@ www.vyletydoostrova.cz
 www.vzyat-zaym.ru
 www.w3bt.com
 www.w3gator.com
-www.w3.org
 www.w7home.cn
 www.waaraproduction.com
 www.wademartinstudios.com


### PR DESCRIPTION
Removes the homepage of the World Wide Web Consortium form the blocklist.