### PR TITLE
Remove valid domain app.n26.com

### DIFF
--- a/Blocklisten/Phishing-Angriffe
+++ b/Blocklisten/Phishing-Angriffe
@@ -8234,7 +8234,6 @@ app.myactivex.com
 app-n26-anagraficiconferma.info
 app-n26-anagraficiconfermare.icu
 app-n26-anagraficiconfermato.info
-app.n26.com
 app.n26.com.login.attivatoservizio.com
 app-n26.com.login.attivatotuoconto.com
 app-n26.com.login.attivatoutente.com


### PR DESCRIPTION
Hi,
die domain `app.n26.com` wird für Online-Banking verwendet und ist keine Phishing-Domain.

Grüße,
Linus

--

English:
Hi,
the domain `app.n26.com` is used by online banking and is not a phishing domains.

Geetings,
Linus