### PR TITLE
Update spam.mails

### DIFF
--- a/Blocklisten/spam.mails
+++ b/Blocklisten/spam.mails
@@ -7,7 +7,9 @@
 # tracker-radar, cybercrime-tracker.net, openphish.com, zonefiles.io, ut-capitole.fr, isc.sans.edu,
 # github.com/disconnectme, phishstats.info, easylist.to, cyberthreatcoalition.org, phishing.army, 
 # google.com sowie lumendatabase.org.
-# 
+#
+gutscheingratis.info
+www.gutscheingratis.info
 casualfrugal.de
 voluptatibusgjca.pulsegrid.de
 meetsap.com


### PR DESCRIPTION
gutscheingratis.info aus #354 hinzugefügt.