### PR TITLE
Update whitelist

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1,3 +1,4 @@
+fonts.googleapis.com
 www.ovh.com
 ovh.com
 www.digitalocean.com


### PR DESCRIPTION
fonts.googleapis.com hinzugefügt, siehe #356