### PR TITLE
Update whitelist

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1,3 +1,4 @@
+mesg.ebay.de
 fonts.googleapis.com
 www.ovh.com
 ovh.com


### PR DESCRIPTION
mesg.ebay.de hinzugefügt.
Jetzt kann das eBay Kundenkonto wieder aufgerufen werden.