### PR TITLE
Update whitelist

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1,3 +1,4 @@
+i2.wp.com
 fonts.googleapis.com
 www.ovh.com
 ovh.com


### PR DESCRIPTION
Bilder auf https://9to5mac.com/ wurden nicht geladen.