### PR TITLE
i2.wp.com hinzugefügt

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1,3 +1,4 @@
+i2.wp.com
 www.iheart.com
 iheart.com
 sf16-muse-va.ibytedtos.com


### PR DESCRIPTION
i2.wp.com hinzugefügt, da ansonsten die Artikelfotos von https://9to5mac.com/ nicht laden.