### PR TITLE
Add the CoinBlockerLists to help administrators protect their networks against cryptomining.

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -77,6 +77,10 @@ https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
 # Phishing
 * https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe
 
+# Coinmining / Cryptojacking
+* https://zerodot1.gitlab.io/CoinBlockerLists/hosts / [CoinBlockerLists Homepage](https://zerodot1.gitlab.io/CoinBlockerListsWeb/)
+* https://zerodot1.gitlab.io/CoinBlockerLists/hosts_browser
+
 # Diverse - All-in-One Listen
 
 * https://dbl.oisd.nl/ (Ads, Mobile Ads, Phishing, Malvertising, Malware, Spyware, Ransomware, CryptoJacking and some Telemetry, Analytics, Tracking)


### PR DESCRIPTION
In some networks it is very important to have protection against cryptomining as well.
No list is perfect, but the CoinBlockerLists have already saved many people's asses.
This is the reason why the lists should not be missing in any Pi-Hole.

If you have any suggestions or feedback just [contact me](https://twitter.com/zero_dot1?lang=en).

Thanks.