### PR TITLE
Update whitelist

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1,3 +1,5 @@
+de.trustpilot.de
+www.de.trustpilot.de
 i2.wp.com
 www.iheart.com
 iheart.com


### PR DESCRIPTION
de.trustpilot.de und  www.de.trustpilot.de hinzugefügt.