### PR TITLE
PayPal Phising mail

### DIFF
--- a/Blocklisten/spam.mails
+++ b/Blocklisten/spam.mails
@@ -499,3 +499,4 @@ zeitsonline.blogspot.com
 zhengzhouseo.cyou
 zingotdeal.tk
 zipocodersioe.store
+servmailapp-supportaccount.duckdns.org


### PR DESCRIPTION
PayPal Phising mail Adresse hinzugefügt.

https://servmailapp-supportaccount.duckdns.org/myaccount/?key=93fe1f03f1b693a246fc1a0beb73fd6657817d5c