### PR TITLE
Add i.scdn.co to whitelist

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1060,6 +1060,7 @@ samsung.com
 sandboxie.com
 sa.symcb.com
 savefrom.net
+i.scdn.co
 scdn.co
 scol.com
 scribd.com

--- a/regex.list
+++ b/regex.list
@@ -19,6 +19,11 @@
 # Sperrt alle Domains aus China, Russland, Sowjetunion, Kolumbien, Vietnam sowie die .top-TLD, aus der scheinbar nur Spammails kommen:
 (\.cn$|\.ru$|\.su$|\.co$|\.vn$|\.top$)
 
+# Wenn Sie den obigen RegEx und Spotify verwenden, werden die Album-Covers nicht mehr geladen, da die von der Domain i.scdn.co geladen werden.
+# Hierzu einfach eine Whitelist-Regel für
+i.scdn.co
+# hinzufügen
+
 # Sperrt alle Domains der TLD .link: (Linkverkürzer)
 \.link$
 


### PR DESCRIPTION
If you have the regex (\.cn$|\.ru$|\.su$|\.co$)|\.vn$|\.top$) active and using Spotify, it is overclocking the album cover images.

+ Domain i.scdn.co in whitelist
+ Hint in regex.list regarding the above regex