### PR TITLE
duckdns.org aus crypto entfernen

### DIFF
--- a/Blocklisten/crypto
+++ b/Blocklisten/crypto
@@ -5454,7 +5454,6 @@ dub.pool.mn
 dubzmzpdkddi.com
 duchmcmpmqqu.com
 duck.crypto-pool.fr
-duckdns.org
 duck.extremepool.org
 ducknote.crypto-pool.fr
 ducknote.xminingpool.com
@@ -23092,7 +23091,6 @@ www.dubijsirwtwq.com
 www.dub.pool.mn
 www.dubzmzpdkddi.com
 www.duchmcmpmqqu.com
-www.duckdns.org
 www.duck.extremepool.org
 www.dueybqnkkhzdh.bid
 www.dugipools.org


### PR DESCRIPTION
DuckDNS selbst hat offensichtlich nichts mit Cryptomining zu tun, allenfalls schädliche Unterdomains (welche bereits teilweise in der Liste vorhanden sind).

Wer DuckDNS komplett sperren möchte kann den Regex-Filter benutzen (https://github.com/RPiList/specials/pull/470), allerdings richtet das in der aktuellen Form meiner Meinung nach mehr Schaden an als es nützt (hat mich zumindest aus dem VPN ausgesperrt).