### PR TITLE
Add sortlink domains

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -2334,4 +2334,9 @@ jtn8it.xxxlutz.at
 kh4y4t.xxxlutz.at
 schrankkonfigurator.xxxlutz.at
 assets.bose.com
-
+0cn.de
+www.0cn.de
+t1p.de
+www.t1p.de
+kurzelinks.de
+www.kurzelinks.de


### PR DESCRIPTION
0cn.de, t1p.de und kurzelinks.de sind seriöse Kurzlinkdomains (selber Anbieter).

Vorteile: Malware-, Phishingschutz, Derefferer usw. (sh. https://t1p.de/faq)

daher in die Whitelist gepackt.