### PR TITLE
Fake Shops hinzugefügt

### DIFF
--- a/Blocklisten/spam.mails
+++ b/Blocklisten/spam.mails
@@ -608,3 +608,5 @@ zeitsonline.blogspot.com
 zhengzhouseo.cyou
 zingotdeal.tk
 zipocodersioe.store
+playstation-sony.eu
+www.playstation-sony.eu


### PR DESCRIPTION
Siehe auch: https://www.heise.de/news/Fake-Shop-taeuscht-PS5-Kunden-Warnung-vor-playstation-sony-eu-6007971.html