### PR TITLE
Deprecated blocklist

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -58,7 +58,6 @@ https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
 
 # Malware
 * https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
-* https://www.malwaredomainlist.com/hostslist/hosts.txt
 * https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-malware.txt
 * https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/crypto
 * https://v.firebog.net/hosts/Prigent-Malware.txt


### PR DESCRIPTION
The blocklist https://www.malwaredomainlist.com/hostslist/hosts.txt appears to be deprecated (since at least Tue, 06 Apr 21 05:07:38 +0000) as it only lists a localhost loopback. In addition HTTPS certificate expired on March 10, 2021 consequently Pi-hole refuses to download the list as it refuses to connect to host.