### PR TITLE
Profile pictures, media server and naming scheme on file

### DIFF
--- a/Internet Services/WhatsApp
+++ b/Internet Services/WhatsApp
@@ -7,3 +7,5 @@ whatsapp.net
 www.whatsapp.com
 www.whatsapp.net
 web.whatsapp.com
+pps.whatsapp.net
+media-vie1-1.cdn.whatsapp.net


### PR DESCRIPTION
A common false/positive on some blocklists. pps.whatsapp.net handles profile pictures and media-vie1-1.cdn.whatsapp.net is necessary for media download/upload (images, videos, etc.) on WhatsApp. Also to keep an uniform naming scheme please use camel case on filename (WhatsApp instead of Whatsapp).