### PR TITLE
Preview images on Twitch

### DIFF
--- a/Internet Services/Twitch
+++ b/Internet Services/Twitch
@@ -12,3 +12,4 @@ www.twitchcdn.net
 www.twitchsvc.net
 twitch.map.fastly.net
 api.twitch.tv
+static-cdn.jtvnw.net


### PR DESCRIPTION
Twitch site kinda breaks with static-cdn.jtvnw.net on blocklist. Site functionality kinda works, but preview images won't load.