### PR TITLE
Allow Twitch extensions

### DIFF
--- a/Internet Services/Twitch
+++ b/Internet Services/Twitch
@@ -13,3 +13,4 @@ www.twitchsvc.net
 twitch.map.fastly.net
 api.twitch.tv
 static-cdn.jtvnw.net
+supervisor.ext-twitch.tv


### PR DESCRIPTION
As mentioned in your Twitch stream on Wednesday, I didn't see the streaming schedule on the the Twitch profile. On further inspection I noticed that by whitelisting supervisor.ext-twitch.tv the extension (countdown until next stream) now shows up.