### PR TITLE
Deprecated blocklist

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -65,6 +65,7 @@ https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
 * https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
 * https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts
 * https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt
+* https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADomains.txt
 * https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt
 * https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts
 * https://urlhaus.abuse.ch/downloads/hostfile/

--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -65,7 +65,6 @@ https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
 * https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
 * https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts
 * https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt
-* https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts_without_controversies.txt
 * https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt
 * https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts
 * https://urlhaus.abuse.ch/downloads/hostfile/


### PR DESCRIPTION
The blocklist https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts_without_controversies.txt appears to be deprecated, see comment section in the file. Maybe https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts.txt should be added, but file needs adjusting (removing 0.0.0.0) on every line.