### PR TITLE
Add 'user-images.githubusercontent.com' to whitelist

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -463,6 +463,7 @@ gigabyte.com
 giga.de
 giphy.com
 gist.githubusercontent.com
+user-images.githubusercontent.com
 github.com
 github.io
 git.io


### PR DESCRIPTION
This sub domain resides in crypto block list.
