### PR TITLE
added impffrei.work

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -10632,6 +10632,7 @@ imperialcontinentalb.com
 imperialonline.es
 imperialxpresscargo.com
 imperun.ru
+impffrei.work
 impkeys.com
 impresatogni.com
 improbuehne.de


### PR DESCRIPTION
added impffrei.work to the list; a jobportal for non vaccinated people. Not a scam in this way, but an untrustworthy service, which also has a pretty bad moral choice.