### PR TITLE
added impffrei.love to notserious

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -10969,6 +10969,7 @@ imperialcontinentalb.com
 imperialonline.es
 imperialxpresscargo.com
 imperun.ru
+impffrei.love
 impffrei.work
 impkeys.com
 impresatogni.com


### PR DESCRIPTION
added impffrei.love to the list; a datingwebsite for non vaccinated people. Again not a scam in this way, but an untrustworthy service, which again has a pretty bad moral choice!