### PR TITLE
Removed www.ti.com from Blocklisten/notserious

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -72464,7 +72464,6 @@ www.thwitcher.com
 www.thwwitcher.com
 www.thyroidi.com
 www.thyspuppies.com
-www.ti.com
 www.tiaabankonline.com
 www.tianustores.com
 www.tibet-med.net


### PR DESCRIPTION
www.ti.com is the official website of Texas Instruments

Related to Issue #660 