### PR TITLE
reformated Blocklisten.md to make it work with pihole-updatelists

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -1,98 +1,169 @@
 # Blocklisten zur Ergänzung nach eigenem Ermessen. Die Listen stammen teilweise von Dritten und können daher nicht auf Richtigkeit geprüft werden. Doppelnennungen möglich.
 
 # Eigene Listen (Copy & Paste):
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Streaming
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/spam.mails
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/easylist
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/samsung
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock1
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock2
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock3
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock4
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/proxies
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/crypto
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/gambling
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/child-protection
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Fake-Science
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Corona-Blocklist
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/MS-Office-Telemetry
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/DomainSquatting
 
 # Listen von Drittanbietern
 
 # Pi-hole Standardlisten
+
 https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
 
 # Listen, sortiert nach Themen, inkl. Listen von Drittanbietern.:
 
 # Tracking
+
 https://raw.github.com/notracking/hosts-blocklists/master/hostnames.txt
+
 https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt
+
 https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/android-tracking.txt
+
 https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
+
 https://raw.githubusercontent.com/wlqY8gkVb9w1Ck5MVD4lBre9nWJez8/W10TelemetryBlocklist/master/W10TelemetryBlocklist
+
 https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt
+
 https://v.firebog.net/hosts/Easyprivacy.txt
+
 https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
+
 https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-blocklist.txt
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/samsung
+
 https://www.github.developerdan.com/hosts/lists/ads-and-tracking-extended.txt
+
 https://hostfiles.frogeye.fr/firstparty-trackers-hosts.txt
+
 https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_justdomains.txt
 
 # Jugendschutz
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock1
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock2
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock3
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock4
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/gambling
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/child-protection
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/proxies
 
 # Fakeshops und Abofallen
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Streaming
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
+
 https://raw.githubusercontent.com/Monstanner/DuckDuckGo-Fakeshops-Blocklist/main/Blockliste
+
 https://raw.githubusercontent.com/Zelo72/rpi/master/pihole/blocklists/fake.txt
 
 # Werbung
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/easylist
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/spam.mails
+
 https://raw.githubusercontent.com/anudeepND/blacklist/master/adservers.txt
+
 https://v.firebog.net/hosts/Easyprivacy.txt
+
 https://v.firebog.net/hosts/Easylist.txt
+
 https://v.firebog.net/hosts/Prigent-Ads.txt
+
 https://v.firebog.net/hosts/AdguardDNS.txt
+
 https://adaway.org/hosts.txt
+
 https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
+
 https://raw.githubusercontent.com/FadeMind/hosts.extras/master/UncheckyAds/hosts
 
-
 # Malware
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
+
 https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-malware.txt
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/crypto
+
 https://v.firebog.net/hosts/Prigent-Malware.txt
+
 https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt
+
 https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
+
 https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts
+
 https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt
+
 https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADomains.txt
+
 https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt
+
 https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts
+
 https://urlhaus.abuse.ch/downloads/hostfile/
+
 https://raw.githubusercontent.com/AmnestyTech/investigations/master/2021-07-18_nso/domains.txt
 
 # Phishing
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe
+
 https://raw.githubusercontent.com/namePlayer/dhl-scamlist/main/dns-blocklists/pihole-blacklist
 
 # Coinmining / Cryptojacking
+
 https://zerodot1.gitlab.io/CoinBlockerLists/hosts
 
 # Diverse
@@ -114,20 +185,37 @@ https://raw.githubusercontent.com/SoftCreatR/fakerando-domains/main/all.txt
 # Einzelne Dienste sperren
 
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Amazon.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Baidu.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Google.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/HP.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/LG.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Samsung.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Synology.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Twitch.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Ubisoft.txt
+
 https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Xiaomi.txt
+
 https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt
+
 https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/android-tracking.txt
+
 https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt
+
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
+
 https://raw.githubusercontent.com/wlqY8gkVb9w1Ck5MVD4lBre9nWJez8/W10TelemetryBlocklist/master/W10TelemetryBlocklist
+
 https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt
+
 https://raw.githubusercontent.com/jmdugan/blocklists/master/corporations/facebook/all
+
 https://raw.githubusercontent.com/ChefTyler/MiscHostsFiles/master/ChanBlocker.txt

--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -1,130 +1,133 @@
 # Blocklisten zur Ergänzung nach eigenem Ermessen. Die Listen stammen teilweise von Dritten und können daher nicht auf Richtigkeit geprüft werden. Doppelnennungen möglich.
 
 # Eigene Listen (Copy & Paste):
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Streaming
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/spam.mails
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/easylist
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/samsung
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock1
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock2
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock3
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock4
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/proxies
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/crypto
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/gambling
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/child-protection
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Fake-Science
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Corona-Blocklist
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/MS-Office-Telemetry
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/DomainSquatting
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Streaming
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/spam.mails
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/easylist
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/samsung
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock1
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock2
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock3
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock4
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/proxies
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/crypto
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/gambling
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/child-protection
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Fake-Science
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Corona-Blocklist
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/MS-Office-Telemetry
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/DomainSquatting
 
 # Listen von Drittanbietern
 
- Pi-hole Standardlisten
-* https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+# Pi-hole Standardlisten
+https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
 
 # Listen, sortiert nach Themen, inkl. Listen von Drittanbietern.:
 
 # Tracking
-* https://raw.github.com/notracking/hosts-blocklists/master/hostnames.txt
-* https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt
-* https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/android-tracking.txt
-* https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
-* https://raw.githubusercontent.com/wlqY8gkVb9w1Ck5MVD4lBre9nWJez8/W10TelemetryBlocklist/master/W10TelemetryBlocklist
-* https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt
-* https://v.firebog.net/hosts/Easyprivacy.txt
-* https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
-* https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-blocklist.txt
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/samsung
-* https://www.github.developerdan.com/hosts/lists/ads-and-tracking-extended.txt
-* https://hostfiles.frogeye.fr/firstparty-trackers-hosts.txt
-* https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_justdomains.txt
+https://raw.github.com/notracking/hosts-blocklists/master/hostnames.txt
+https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt
+https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/android-tracking.txt
+https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
+https://raw.githubusercontent.com/wlqY8gkVb9w1Ck5MVD4lBre9nWJez8/W10TelemetryBlocklist/master/W10TelemetryBlocklist
+https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt
+https://v.firebog.net/hosts/Easyprivacy.txt
+https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
+https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-blocklist.txt
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/samsung
+https://www.github.developerdan.com/hosts/lists/ads-and-tracking-extended.txt
+https://hostfiles.frogeye.fr/firstparty-trackers-hosts.txt
+https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_justdomains.txt
 
 # Jugendschutz
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock1
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock2
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock3
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock4
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/gambling
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/child-protection
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/proxies
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock1
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock2
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock3
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/pornblock4
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/gambling
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/child-protection
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/proxies
 
 # Fakeshops und Abofallen
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Streaming
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
-* https://raw.githubusercontent.com/Monstanner/DuckDuckGo-Fakeshops-Blocklist/main/Blockliste
-* https://raw.githubusercontent.com/Zelo72/rpi/master/pihole/blocklists/fake.txt
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Streaming
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
+https://raw.githubusercontent.com/Monstanner/DuckDuckGo-Fakeshops-Blocklist/main/Blockliste
+https://raw.githubusercontent.com/Zelo72/rpi/master/pihole/blocklists/fake.txt
 
 # Werbung
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/easylist
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/spam.mails
-* https://raw.githubusercontent.com/anudeepND/blacklist/master/adservers.txt
-* https://v.firebog.net/hosts/Easyprivacy.txt
-* https://v.firebog.net/hosts/Easylist.txt
-* https://v.firebog.net/hosts/Prigent-Ads.txt
-* https://v.firebog.net/hosts/AdguardDNS.txt
-* https://adaway.org/hosts.txt
-* https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
-* https://raw.githubusercontent.com/FadeMind/hosts.extras/master/UncheckyAds/hosts
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/easylist
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/spam.mails
+https://raw.githubusercontent.com/anudeepND/blacklist/master/adservers.txt
+https://v.firebog.net/hosts/Easyprivacy.txt
+https://v.firebog.net/hosts/Easylist.txt
+https://v.firebog.net/hosts/Prigent-Ads.txt
+https://v.firebog.net/hosts/AdguardDNS.txt
+https://adaway.org/hosts.txt
+https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
+https://raw.githubusercontent.com/FadeMind/hosts.extras/master/UncheckyAds/hosts
 
 
 # Malware
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
-* https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-malware.txt
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/crypto
-* https://v.firebog.net/hosts/Prigent-Malware.txt
-* https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt
-* https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
-* https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts
-* https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt
-* https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADomains.txt
-* https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt
-* https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts
-* https://urlhaus.abuse.ch/downloads/hostfile/
-* https://raw.githubusercontent.com/AmnestyTech/investigations/master/2021-07-18_nso/domains.txt
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
+https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-malware.txt
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/crypto
+https://v.firebog.net/hosts/Prigent-Malware.txt
+https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt
+https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
+https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts
+https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt
+https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADomains.txt
+https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt
+https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts
+https://urlhaus.abuse.ch/downloads/hostfile/
+https://raw.githubusercontent.com/AmnestyTech/investigations/master/2021-07-18_nso/domains.txt
 
 # Phishing
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe
-* https://raw.githubusercontent.com/namePlayer/dhl-scamlist/main/dns-blocklists/pihole-blacklist
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe
+https://raw.githubusercontent.com/namePlayer/dhl-scamlist/main/dns-blocklists/pihole-blacklist
 
 # Coinmining / Cryptojacking
-* https://zerodot1.gitlab.io/CoinBlockerLists/hosts
+https://zerodot1.gitlab.io/CoinBlockerLists/hosts
 
 # Diverse
 
-* https://dbl.oisd.nl/ (Ads, Mobile Ads, Phishing, Malvertising, Malware, Spyware, Ransomware, CryptoJacking and some Telemetry, Analytics, Tracking)
-* https://raw.githubusercontent.com/Zelo72/rpi/master/pihole/blocklists/multi.txt (Werbung, Tracking, Phishing, Malware und Coinmining)
-* https://v.firebog.net/hosts/static/w3kbl.txt (Ads, CryptoJacking, Telemetry, Tracking)
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Fake-Science
-* https://raw.githubusercontent.com/SoftCreatR/fakerando-domains/main/all.txt (Lieferando Shadow-Fake-Websites)
+https://dbl.oisd.nl/
+#(Ads, Mobile Ads, Phishing, Malvertising, Malware, Spyware, Ransomware, CryptoJacking and some Telemetry, Analytics, Tracking)
 
+https://raw.githubusercontent.com/Zelo72/rpi/master/pihole/blocklists/multi.txt
+#(Werbung, Tracking, Phishing, Malware und Coinmining)
 
+https://v.firebog.net/hosts/static/w3kbl.txt
+#(Ads, CryptoJacking, Telemetry, Tracking)
+
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Fake-Science
+
+https://raw.githubusercontent.com/SoftCreatR/fakerando-domains/main/all.txt
+#(Lieferando Shadow-Fake-Websites)
 
 # Einzelne Dienste sperren
 
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Amazon.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Baidu.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Google.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/HP.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/LG.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Samsung.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Synology.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Twitch.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Ubisoft.txt
-* https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Xiaomi.txt
-* https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt
-* https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/android-tracking.txt
-* https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt
-* https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
-* https://raw.githubusercontent.com/wlqY8gkVb9w1Ck5MVD4lBre9nWJez8/W10TelemetryBlocklist/master/W10TelemetryBlocklist
-* https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt
-* https://raw.githubusercontent.com/jmdugan/blocklists/master/corporations/facebook/all
-* https://raw.githubusercontent.com/ChefTyler/MiscHostsFiles/master/ChanBlocker.txt
-
-
-
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Amazon.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Baidu.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Google.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/HP.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/LG.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Samsung.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Synology.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Twitch.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Ubisoft.txt
+https://raw.githubusercontent.com/bloodhunterd/pi-hole-blocklists/master/Xiaomi.txt
+https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt
+https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/android-tracking.txt
+https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/AmazonFireTV.txt
+https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
+https://raw.githubusercontent.com/wlqY8gkVb9w1Ck5MVD4lBre9nWJez8/W10TelemetryBlocklist/master/W10TelemetryBlocklist
+https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt
+https://raw.githubusercontent.com/jmdugan/blocklists/master/corporations/facebook/all
+https://raw.githubusercontent.com/ChefTyler/MiscHostsFiles/master/ChanBlocker.txt


### PR DESCRIPTION
jacklul/pihole-updatelists (https://github.com/jacklul/pihole-updatelists) is a tool that allows to automatically import newly added lists into the Pi-hole. For it to work, it needs to be formatted correctly. So I removed the asterisk before the URLs and put the "comments" in separate lines and commented it out. By this change it allows me to define Blocklisten.md as a source without spitting errors.