### PR TITLE
Entferne privatedns.org und füge clouddrop.tk als Downloadquelle hinzu

### DIFF
--- a/Download.md
+++ b/Download.md
@@ -10,11 +10,11 @@ md5: ce4974bd53e4b9b6a8f9f38f4570fe00 <br>
 
 Weitere Download-Quellen:<br>
 
-- https://cdn.privatedns.org/svpihole/svpihole2103.zip
 - https://bafybeieiw37hap64ayjirt2nugckwlmj7rm3qguzkpyauzdugqiqo5seeu.ipfs.dweb.link
 - https://bafybeieiw37hap64ayjirt2nugckwlmj7rm3qguzkpyauzdugqiqo5seeu.ipfs.cf-ipfs.com
 - https://ipfs.io/ipfs/QmXYKzninZE5s9DHWYtExvuQwoDFU9SBxXdwFrthBFBMAU?filename=svpihole2013.zip
 - https://heldendesbildschirms.dynv6.net/download/software/betriebssysteme/svpihole/
+- https://cdn.clouddrop.tk/svpihole/svpihole2103.zip
 <br>
 <br>
 
@@ -32,11 +32,11 @@ md5: 21a5719d26e439333ccc243182d2b0c2 <br>
 
 Weitere Download-Quellen:<br>
 
-- https://cdn.privatedns.org/svpihole/svPiholeVM2105.zip
 - https://bafybeibf2e256taj642lknfmhzfml57yigl2uqy3qhvbuslvvvmokdt2ce.ipfs.dweb.link
 - https://bafybeibf2e256taj642lknfmhzfml57yigl2uqy3qhvbuslvvvmokdt2ce.ipfs.cf-ipfs.com
 - https://ipfs.io/ipfs/QmQtGpaXT3uRWx2oZ69chxrKJS7TMaKPuUgzSeP3QkpkTz?filename=svPiholeVM2103.zip
 - https://heldendesbildschirms.dynv6.net/download/software/betriebssysteme/svPiholeVM/
+- https://cdn.clouddrop.tk/svpihole/svPiholeVM2105.zip
 <br>
 <br>
 


### PR DESCRIPTION
Die Domain privatedns.org und damit die Subdomain/Downloadquelle cdn.privatedns.org ist nicht mehr aktiv. Deswegen habe ich sie aus den Downloadquellen entfernt.
Neu hinzugekommen ist cdn.clouddrop.tk als Downloadquelle.