### PR TITLE
Whitelist Namecheap DNS servers

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -413,6 +413,8 @@ dl.dropboxusercontent.com
 dlvr.it
 dmqdd6hw24ucf.cloudfront.net
 dns.msftncsi.com
+dns1.registrar-servers.com
+dns2.registrar-servers.com
 docmorris.de
 docs.google.com
 docs.live.net


### PR DESCRIPTION
The two domains removed from the easylist file are the DNS servers offered to customers of
namecheap for hosting their DNS records. As far as I know, they do not serve content and there
should not be any reason to block them.

These two domains:

* dns1.registrar-servers.com
* dns2.registrar-servers.com

are used by Namecheap (the domain registar) to offer DNS services to their customers. To the best of my knowledge, they do not serve content and blacklisting them can only cause trouble.

Namecheap [list these nameservers here in their knowledgebase](https://www.namecheap.com/support/knowledgebase/article.aspx/766/10/what-is-dns-server-name-server/), for example.

(I noticed these entries when I wanted to look up the IP addresses of my domain's nameservers)