### PR TITLE
Added kodi-tipps.de to notserious list

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -20537,6 +20537,7 @@ kockstarter.com
 kodekarten.club
 kodero.de
 kodero.eu
+kodi-tipps.de
 koelle-bike.de
 koeln-bonner-eisenbahn.de
 koenig-elektroshop.com
@@ -63710,6 +63711,7 @@ www.kockstarter.com
 www.kodekarten.club
 www.kodero.de
 www.kodero.eu
+www.kodi-tipps.de
 www.koelle-bike.de
 www.koeln-bonner-eisenbahn.de
 www.koenig-elektroshop.com


### PR DESCRIPTION
This blog recommends addons and repositories banned from Kodi. 