### PR TITLE
🚸 Remove false positive (www.)ip-api.com

### DIFF
--- a/dev/DDG-Brave-DisconnectMe
+++ b/dev/DDG-Brave-DisconnectMe
@@ -6470,7 +6470,6 @@ ip2map.com
 ip2phrase.com
 ipaddresslabs.com
 ipapi.co
-ip-api.com
 i-parcel.com
 ipcatch.com
 ipcounter.de
@@ -17847,7 +17846,6 @@ www.ip2map.com
 www.ip2phrase.com
 www.ipaddresslabs.com
 www.ipapi.co
-www.ip-api.com
 www.i-parcel.com
 www.ipcatch.com
 www.ipcounter.de


### PR DESCRIPTION
This PR removes (www.)ip-api.com which is a false positive (and I really don't know WHY and HOW children should or would use this domain!? 😜). It has been also removed from other major blocklists:
https://blocklist-tools.developerdan.com/entries/search?q=ip-api.com

I will also inform the owners of the remaining lists to remove this domain(s).

Because of this blocklist entry, someone isn't able to gather ASN infos for a given IP or domain 😞 
```
# https://github.com/trimstray/the-book-of-secret-knowledge#shell-functions-toc
function getASN () {
    local _ip="$1";
    local _curl_base="curl --request GET";
    local _timeout="15";
    _asn=$($_curl_base -ks -m "$_timeout" "http://ip-api.com/line/${_ip}?fields=as");
    _state=$(echo $?);
    if [[ -z "$_ip" ]] || [[ "$_ip" == "null" ]] || [[ "$_state" -ne 0 ]]; then
        echo -en "Unsuccessful ASN gathering.\\n";
    else
        echo -en "$_ip > $_asn\\n";
    fi
}
```