### PR TITLE
 Remove False Positive phishing domain: (www.)irs.gov

### DIFF
--- a/Blocklisten/Phishing-Angriffe
+++ b/Blocklisten/Phishing-Angriffe
@@ -41943,7 +41943,6 @@ irs.federalonlinegettaxs.com
 irs.federalusa-taxsclaim.com
 irs.federalusaonline.com
 irs.get-paymentfederal.com
-irs.gov
 irs.homefederalusa.com
 irs.payment-safepay.com
 irs.paymentfeunds-online.com
@@ -118375,7 +118374,6 @@ www.irs-tax-refunds.com
 www.irs-tax-reward.com
 www.irs-taxprofile-info.com
 www.irs-ticket.com
-www.irs.gov
 www.irsget-payment-taxinformation.com
 www.irsgov.pics
 www.irsgovpayment.com


### PR DESCRIPTION
 This is the official domain of the internal revenue service of the United States of America.