### PR TITLE
Add Inversion blocklist

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -166,6 +166,8 @@ https://raw.githubusercontent.com/AmnestyTech/investigations/master/2021-07-18_n
 
 https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/tif.txt
 
+https://raw.githubusercontent.com/elliotwutingfeng/Inversion-DNSBL-Blocklists/main/Google_hostnames.txt
+
 # Phishing
 
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe


### PR DESCRIPTION
Malicious URL blocklist automatically updated every 24 hours by scanning various public URL sources using the Safe Browsing API from [Google](https://developers.google.com/safe-browsing).

GitHub repo: https://github.com/elliotwutingfeng/Inversion-DNSBL-Blocklists

Current size (20 June 2022): **632,769** URLs