### PR TITLE
Extend Windows 10 Telemetry to 21H2 and 1809 lists of BSI

### DIFF
--- a/Blocklisten/Win10Telemetry
+++ b/Blocklisten/Win10Telemetry
@@ -9,26 +9,52 @@
 # google.com sowie lumendatabase.org.
 # 
 # Offizielle Liste des BSI gem. https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Cyber-Sicherheit/SiSyPHus/Analyse_Telemetriekomponente_1_2.pdf?__blob=publicationFile&v=6
+# Offizielle BSI Liste für Windows 1809: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Cyber-Sicherheit/SiSyPHus/Telemetrie-Endpunkte_Windows10_Build_1809.xlsx?__blob=publicationFile&v=3
+# Offizielle BSI Liste für Windows 21H2: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Cyber-Sicherheit/SiSyPHus/Telemetrie-Endpunkte_Windows10_Build_Build_21H2.xlsx?__blob=publicationFile&v=3
 
 alpha.telemetry.microsoft.com
 asimov-win.settings.data.microsoft.com.akadns.net
+au-v10.events.data.microsoft.com
+au-v20.events.data.microsoft.com
+au.vortex-win.data.microsoft.com
 ceuswatcab01.blob.core.windows.net
 ceuswatcab02.blob.core.windows.net
+cy2.vortex.data.microsoft.com.akadns.net
 db5-eap.settings-win.data.microsoft.com.akadns.net
 db5.settings-win.data.microsoft.com.akadns.net
 db5.vortex.data.microsoft.com.akadns.net
+de-v20.events.data.microsoft.com
+de.vortex-win.data.microsoft.com
 eaus2watcab01.blob.core.windows.net
 eaus2watcab02.blob.core.windows.net
+eu-v10.events.data.microsoft.com
+eu-v20.events.data.microsoft.com
 eu.vortex-win.data.microsoft.com
+events.data.microsoft.com
+events-sandbox.data.microsoft.com
 geo.settings-win.data.microsoft.com.akadns.net
 geo.vortex.data.microsoft.com.akadns.net
+jp-v10.events.data.microsoft.com
+jp-v20.events.data.microsoft.com
+modern.watson.data.microsoft.com.akadns.net
 oca.telemetry.microsoft.com
 settings-win.data.microsoft.com
+telecommand.telemetry.microsoft.com
+uk-v20.events.data.microsoft.com
+uk.vortex-win.data.microsoft.com
+us4-v20.events.data.microsoft.com
+us5-v20.events.data.microsoft.com
+us-v10.events.data.microsoft.com
+us-v20.events.data.microsoft.com
 us.vortex-win.data.microsoft.com
+v10.events.data.microsoft.com
 v10.vortex-win.data.microsoft.com
 v10-win.vortex.data.microsoft.com.akadns.net
+v20.events.data.microsoft.com
+v20.vortex-win.data.microsoft.com
+vortex-win.data.microsoft.com
 vortex-win-sandbox.data.microsoft.com
+watson.*.microsoft.com
+watson.telemetry.microsoft.com
 weus2watcab01.blob.core.windows.net
 weus2watcab02.blob.core.windows.net
-v10.events.data.microsoft.com
-v20.events.data.microsoft.com


### PR DESCRIPTION
Erweiterung der Domains auf der Windows 10 Telemetrie Liste mithilfe der von BSI angegebenen Domains für 21H2 und 1809.

- https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Cyber-Sicherheit/SiSyPHus/Telemetrie-Endpunkte_Windows10_Build_Build_21H2.html
- https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Cyber-Sicherheit/SiSyPHus/Telemetrie-Endpunkte_Windows10_Build_1809.html
