### PR TITLE
Removed aeotec.com domains from notserious

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -754,7 +754,6 @@ aelogisticsexpress.com
 aelter-leben.de
 aelxa.com
 aemmestore.it
-aeotec.com
 aeowe.com
 aeptecm.com
 aerialpics.de
@@ -39799,7 +39798,6 @@ storbuy.site
 store-go.pro
 store-mart.tech
 store-playstation.eu
-store.aeotec.com
 store.birkvsale.com
 store.birkxsale.com
 store.com
@@ -47348,7 +47346,6 @@ www.aelter-leben.de
 www.aelxa.com
 www.aemmestore.it
 www.aenbk.com
-www.aeotec.com
 www.aeowe.com
 www.aeptecm.com
 www.aerialpics.de


### PR DESCRIPTION
Aeotec is a manufacture of ZigBee and Z-Wave controllers and some other smart devices. I don't know why it's in the notserious list, it's serious and so i removed the domains from the notserious list

Maybe @RPiList can explain why it was on this list