### PR TITLE
added skyticket whitelist

### DIFF
--- a/Internet Services/Sky Ticket
+++ b/Internet Services/Sky Ticket
@@ -1,0 +1,16 @@
+agg.oogwayintl.sky.com
+d3sawt37qbqwk0.cloudfront.net
+de.imageservice.sky.com
+dpm.demdex.net
+eu.api.atom.sky.com
+graphql.ott.sky.com
+hlsvod.p.lb.skycdn.de
+id.sky.de
+mytv.api.nowtv.com
+niio-sgwl.skyanywhere.com
+ott-sgw.skyanywhere.com
+p.sky.com
+persona-store.sky.com
+s.mzstatic.com
+wowtv.de
+www.wowtv.de


### PR DESCRIPTION
Leider muss die Tracking-Domain _dpm.demdex.net_ auf die Whitelist, da der Dienst ansonsten nicht fehlerfrei funktioniert oder gar startet.