### PR TITLE
Remove false positives

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -11595,7 +11595,6 @@ drahtesel-xl.net
 drahtstyle.de
 drakegarden.shop
 dramatischegestalten.de
-dransay.com
 draognage.com
 draonage.com
 dratonage.com
@@ -65691,7 +65690,6 @@ www.drahtesel-xl.net
 www.drahtstyle.de
 www.drakegarden.shop
 www.dramatischegestalten.de
-www.dransay.com
 www.draognage.com
 www.draonage.com
 www.dratonage.com


### PR DESCRIPTION
As the title says, removes a false positive, a legitimate domain that is from a valid and serious (tele-)medicinal company: dransay.com