### PR TITLE
Remove false positives

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -18927,7 +18927,6 @@ gmaiil.com
 gmail.cm
 gmail.cn
 gmail.co
-gmail.com
 gmailcom.com
 gmaitreya.com
 gmal.com


### PR DESCRIPTION
These are legitimate domains:

1. gmail.com used by Google
2. meteoswiss-app.ch used by the Android MeteoSwiss app