### PR TITLE
easy add links to adguardhome

### DIFF
--- a/dev/adguardhome/README.md
+++ b/dev/adguardhome/README.md
@@ -1,0 +1,1 @@
+Die "dev" Abteilung für AdguardHome

--- a/dev/adguardhome/add-links-to-adguardhome.sh
+++ b/dev/adguardhome/add-links-to-adguardhome.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Wenn Adguardhome als Docker Image genutzt wird, dann unter "configfile=" den genauen Pfad der AdGuardHome.yaml zu finden ist
+configfile=/etc/adguardhome/AdGuardHome.yaml
+
+# Die Textdatei in den die Links eingetragen sind. Es dürfen keine Leerzeilen dazwischen sein.
+linkfile=./links.txt
+
+# Vorher in AdguardHome alle bisher bzw. die Standard Listen löschen damit, das Script das besser einfügen kann.
+
+
+sed -i 's/^filters: .*$/ /g' $configfile
+
+echo "filters:" >> $configfile
+
+while read line; do
+    echo "  - enabled: true" >> $configfile
+    echo "    url: $line" >> $configfile
+    echo "    name: $line"  >> $configfile
+    echo "    id: 9$RANDOM" >> $configfile
+done < $linkfile
+
+# Nur verwenden wenn Adguardhome nicht als Docker Image läuft ansonsten auskommentieren.
+systemctl restart adguardhome.service

--- a/dev/adguardhome/add-links-to-adguardhome.sh
+++ b/dev/adguardhome/add-links-to-adguardhome.sh
@@ -6,7 +6,7 @@ configfile=/etc/adguardhome/AdGuardHome.yaml
 # Die Textdatei in den die Links eingetragen sind. Es dürfen keine Leerzeilen dazwischen sein.
 linkfile=./links.txt
 
-# Vorher in AdguardHome alle bisher bzw. die Standard Listen löschen damit, das Script das besser einfügen kann.
+# Vorher in AdguardHome alle bisher eingetragenen bzw. die Standard Listen löschen damit, das Script das besser einfügen kann.
 
 
 sed -i 's/^filters: .*$/ /g' $configfile


### PR DESCRIPTION
I have created a script with which it is possible via a links.txt in which the links to the block lists should be, to intrigue them easily and quickly into the adguardhome config. The prerequisite is that you create a `./links.txt` in the same directory of the script and save the links in it and there must not be any empty lines in between.

before using adguardhome, you have to remove all previous and standard lists so that the script can insert it without errors.

If Adgurdhome is run as a docker image, you have to go to the volume that contains the `adguardhome.yaml` and adjust the full path to the `adguardhome.yaml` in the script and restart the docker container after using the script. 
Instructions written in German can also be found in the script with the `#` sign.

The script has just been put together, so it can't be guaranteed to work, but I tested it under the instructions (see this comment) and it should probably work

Example of how the `./links.txt` should be structured:
```
https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious
https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Streaming
https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe
https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/spam.mails
https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
```

Example of how the `./links.txt` should **not** be structured:
```
https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/notserious

https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Streaming

https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Phishing-Angriffe

https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/spam.mails

https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry
```
