### PR TITLE
remove www.traewelling.de

### DIFF
--- a/Blocklisten/malware
+++ b/Blocklisten/malware
@@ -69805,7 +69805,6 @@ www.traderhype.com
 www.traderiq.net
 www.tradewithnajamahmed.com
 www.tradingneon.com
-www.traewelling.de
 www.trafkintun.cl
 www.trailerkings.ie
 www.trailopenairdemo.com


### PR DESCRIPTION
traewelling.de is a "social network" like website (Open Source Project at https://github.com/traewelling/traewelling) where users can check into trains and see where their friends are. We have received several requests that our users have problems because we are on this list.

I think "malware" is a false positive, so I would request to remove this from this list. :)

Also: Where does the Domains from "Auto Update" commits come from?
