### PR TITLE
Removed false positive mastodon.social

### DIFF
--- a/Blocklisten/malware
+++ b/Blocklisten/malware
@@ -31999,7 +31999,6 @@ mastersofchatgpt.com
 mastertechnologies.net
 masteryourminds.com
 mastionline.in
-mastodon.social
 matajir.ae
 matbakh.com.pk
 match-openair.de
@@ -63446,7 +63445,6 @@ www.mastersofchatgpt.com
 www.mastertechnologies.net
 www.masteryourminds.com
 www.mastionline.in
-www.mastodon.social
 www.matajir.ae
 www.match-openair.de
 www.matchtranslations.com


### PR DESCRIPTION
Removed false positive „mastodon.social“ from malware list.

Fix for #1084