### PR TITLE
add workflow to automatically label issue and pr

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,3 +23,8 @@ question:
     - '(frage|question|fragen|questions|\
         Frage|Question|Fragen|Questions|\
         FRAGE|QUESTION|FRAGEN|QUESTIONS)'
+
+false-positive:
+    - '(false-positive|false positive|falsch positiv|falsch-positiv|falsch positive|falsch-positive|false positiv|false-positiv|\
+        False-Positive|False Positive|Falsch Positiv|Falsch-Positiv|Falsch Positive|Falsch-Positive|False Positiv|False-Positiv|\
+        FALSE-POSITIVE|FALSE POSITIVE|FALSCH POSITIV|FALSCH-POSITIV|FALSCH POSITIVE|FALSCH-POSITIVE|FALSE POSITIV|FALSE-POSITIV)'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+bug:
+    - '(defekt|defect|mangel|mängel|shortcoming|schwäche|weakness|störung|disturbance|fehlfunktion|malfunction|fehlerhaftigkeit|fehlerhaft|fault|error|faultiness|unzulänglichkeit|unzugänglich|inadequacy|bug|fehler|\
+        Defekt|Defect|Mangel|Mängel|Shortcoming|Schwäche|Weakness|Störung|Disturbance|Fehlfunktion|Malfunction|Fehlerhaftigkeit|Fehlerhaft|Fault|Error|Faultiness|Unzulänglichkeit|Unzugänglich|Inadequacy|Bug|Fehler|\
+        DEFEKT|DEFECT|MANGEL|MÄNGEL|SHORTCOMING|SCHWÄCHE|WEAKNESS|STÖRUNG|DISTURBANCE|FEHLFUNKTION|MALFUNCTION|FEHLERHAFTIGKEIT|FEHLERHAFT|FAULT|ERROR|FAULTINESS|UNZULÄNGLICHKEIT|UNZUGÄNGLICH|INADEQUACY|BUG|FEHLER)'
+
+documentation:
+    - '(dokumentation|documentation|aufzeichnung|record|bericht|report|protokoll|protocol|\
+        Dokumentation|Documentation|Aufzeichnung|Record|Bericht|Report|Protokoll|Protocol|\
+        DOKUMENTATION|DOCUMENTATION|AUFZEICHNUNG|RECORD|BERICHT|REPORT|PROTOKOLL|PROTOCOL)'
+    
+
+enhancement:
+    - '(verbesserung|improvement|erweiterung|extension|neuerung|erneuerung|innovation|merkmal|feature|funktion|function|anforderung|requirement|\
+        Verbesserung|Improvement|Erweiterung|Extension|Neuerung|Erneuerung|Innovation|Merkmal|Feature|Funktion|Function|Anforderung|Requirement|\
+        VERBESSERUNG|IMPROVEMENT|ERWEITERUNG|EXTENSION|NEUERUNG|ERNEUERUNG|INNOVATION|MERKMAL|FEATURE|FUNKTION|FUNCTION|ANFORDERUNG|REQUIREMENT)'
+
+help wanted:
+    - '(help|hilfe|\
+        Help|Hilfe|\
+        HELP|HILFE)'
+
+question:
+    - '(frage|question|fragen|questions|\
+        Frage|Question|Fragen|Questions|\
+        FRAGE|QUESTION|FRAGEN|QUESTIONS)'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: "Issue and Pull request Labeler"
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.1 #May not be the latest version
+      with:
+        configuration-path: .github/labeler.yml
+        include-title: 1
+        sync-labels: 1
+        enable-versioned-regex: 0
+        repo-token: ${{ github.token }}


### PR DESCRIPTION
this adds a workflow for automatically labeling issue and pull requests

this makes it possible to use the labels a little better, since labels are assigned automatically depending on the matched word

in the .github/labeler.yml you can add or change the words to be matched and other labels

the words are added as small, upper/lower and capitalized.
e.g.
- question
- Question
- QUESTION

the words are contained in both german and english, which then enables two-language matching
e.g.
- Question
- Frage

example screenshots of how it could look like with an issue and pull request with successful labeling
![Screenshot (73)](https://github.com/RPiList/specials/assets/82592556/ef63e12f-23c2-4684-838e-851cabd6df9b)
![Screenshot (72)](https://github.com/RPiList/specials/assets/82592556/958f046d-2b92-492d-a98b-851d16986ec5)
