### PR TITLE
Improve megalist sh

### DIFF
--- a/MegaList.sh
+++ b/MegaList.sh
@@ -6,7 +6,8 @@ megalist=megalist.txt
 blocklistenmd=https://github.com/RPiList/specials/raw/master/Blocklisten.md
 
 # "n" (no) or "y" (yes)
-abp_style=n
+# Accept cli input, if nothing is provided pass "n"
+abp_style=${1:-n}
 
 # ---------------------------------------------------------------------------
 function cleanup() {

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -38,7 +38,7 @@ cat $linkfile | grep "RPiList/specials" > $linkfile.tmp
 mv $linkfile.tmp $linkfile
 
 
-while read line; do
+while read -r line; do
 	echo downloading $line
 	curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt $line
 	RESULT=$?

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -9,8 +9,12 @@ blocklistenmd=https://github.com/RPiList/specials/raw/master/Blocklisten.md
 abp_style=n
 
 # ---------------------------------------------------------------------------
-rm $linkfile
-rm $blocklistfile-*.txt
+function cleanup() {
+	rm $linkfile
+	rm $blocklistfile-*.txt
+}
+
+cleanup
 
 echo downloading $blocklistenmd
 curl -L -o $linkfile $blocklistenmd
@@ -48,8 +52,7 @@ while read -r line; do
 		RESULT=$?
 		if [ $RESULT -ne 0 ]; then
 			echo downloading "$line" failed again;
-			rm $linkfile
-			rm $blocklistfile-*.txt
+			cleanup
 			exit 1;
 		fi
 	fi
@@ -77,7 +80,6 @@ if [ "$abp_style" != "y" ]; then
 	mv /tmp/$megalist.tmp $megalist
 fi
 
-rm $linkfile
-rm $blocklistfile-*.txt
+cleanup
 
 echo $megalist was created

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -6,7 +6,7 @@ megalist=megalist.txt
 blocklistenmd=https://github.com/RPiList/specials/raw/master/Blocklisten.md
 
 # "n" (no) or "y" (yes)
-abp-style=n
+abp_style=n
 
 # ---------------------------------------------------------------------------
 rm $linkfile
@@ -66,7 +66,7 @@ sort -u /tmp/$megalist > /tmp/$megalist.tmp
 mv /tmp/$megalist.tmp $megalist
 
 
-if [ "$abp-style" != "y" ]; then
+if [ "$abp_style" != "y" ]; then
 	echo remove ABP-Style values out of $megalist
 	sed -i 's/^||.*$//g' $megalist
 	sed -i 's/^@@.*$//g' $megalist

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -39,15 +39,15 @@ mv $linkfile.tmp $linkfile
 
 
 while read -r line; do
-	echo downloading $line
-	curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt $line
+	echo downloading "$line"
+	curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt "$line"
 	RESULT=$?
 	if [ $RESULT -ne 0 ]; then
-		echo downloading $line failed;
-		curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt $line;
+		echo downloading "$line" failed;
+		curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt "$line";
 		RESULT=$?
 		if [ $RESULT -ne 0 ]; then
-			echo downloading $line failed again;
+			echo downloading "$line" failed again;
 			rm $linkfile
 			rm $blocklistfile-*.txt
 			exit 1;


### PR DESCRIPTION
Hi,

ich finde das Konzept der megaliste topp, so muss ich im pi-hole nur eine eine Datei pflegen und nicht x listen mit Duplikaten ;)
Ich hab aber keine Lust jedes mal das Skript anzupassen nur weil ich mal eine liste mit ABP Domains und mal ohne erstellen will...
Daher diese kleine Anpassung die den Schalter (y/n) per cli konfigurierbar macht. Ohne Angabe sollte das Skript weiter mit "n" laufen.
Nebenbei hab ich noch ein paar [shellcheck](https://www.shellcheck.net/) Fehler gefixt