### PR TITLE
Improve megalist sh (addition)

### DIFF
--- a/MegaList.sh
+++ b/MegaList.sh
@@ -6,7 +6,8 @@ megalist=megalist.txt
 blocklistenmd=https://github.com/RPiList/specials/raw/master/Blocklisten.md
 
 # "n" (no) or "y" (yes)
-abp_style=n
+# Accept cli input, if nothing is provided pass "n"
+abp_style=${1:-n}
 
 # ---------------------------------------------------------------------------
 function cleanup() {

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -38,7 +38,7 @@ cat $linkfile | grep "RPiList/specials" > $linkfile.tmp
 mv $linkfile.tmp $linkfile
 
 
-while read line; do
+while read -r line; do
 	echo downloading $line
 	curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt $line
 	RESULT=$?

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -9,8 +9,12 @@ blocklistenmd=https://github.com/RPiList/specials/raw/master/Blocklisten.md
 abp_style=n
 
 # ---------------------------------------------------------------------------
-rm $linkfile
-rm $blocklistfile-*.txt
+function cleanup() {
+	rm $linkfile
+	rm $blocklistfile-*.txt
+}
+
+cleanup
 
 echo downloading $blocklistenmd
 curl -L -o $linkfile $blocklistenmd
@@ -48,8 +52,7 @@ while read -r line; do
 		RESULT=$?
 		if [ $RESULT -ne 0 ]; then
 			echo downloading "$line" failed again;
-			rm $linkfile
-			rm $blocklistfile-*.txt
+			cleanup
 			exit 1;
 		fi
 	fi
@@ -77,7 +80,6 @@ if [ "$abp_style" != "y" ]; then
 	mv /tmp/$megalist.tmp $megalist
 fi
 
-rm $linkfile
-rm $blocklistfile-*.txt
+cleanup
 
 echo $megalist was created

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -6,7 +6,7 @@ megalist=megalist.txt
 blocklistenmd=https://github.com/RPiList/specials/raw/master/Blocklisten.md
 
 # "n" (no) or "y" (yes)
-abp-style=n
+abp_style=n
 
 # ---------------------------------------------------------------------------
 rm $linkfile
@@ -66,7 +66,7 @@ sort -u /tmp/$megalist > /tmp/$megalist.tmp
 mv /tmp/$megalist.tmp $megalist
 
 
-if [ "$abp-style" != "y" ]; then
+if [ "$abp_style" != "y" ]; then
 	echo remove ABP-Style values out of $megalist
 	sed -i 's/^||.*$//g' $megalist
 	sed -i 's/^@@.*$//g' $megalist

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -39,15 +39,15 @@ mv $linkfile.tmp $linkfile
 
 
 while read -r line; do
-	echo downloading $line
-	curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt $line
+	echo downloading "$line"
+	curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt "$line"
 	RESULT=$?
 	if [ $RESULT -ne 0 ]; then
-		echo downloading $line failed;
-		curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt $line;
+		echo downloading "$line" failed;
+		curl -L -o $blocklistfile-$RANDOM$RANDOM$RANDOM.txt "$line";
 		RESULT=$?
 		if [ $RESULT -ne 0 ]; then
-			echo downloading $line failed again;
+			echo downloading "$line" failed again;
 			rm $linkfile
 			rm $blocklistfile-*.txt
 			exit 1;

--- a/MegaList.sh
+++ b/MegaList.sh
@@ -10,6 +10,18 @@ blocklistenmd=https://github.com/RPiList/specials/raw/master/Blocklisten.md
 abp_style=${1:-n}
 
 # ---------------------------------------------------------------------------
+if [ "$abp_style" != "y" ] && [ "$abp_style" != "n" ]; then
+	echo please enter "n" for no or "y" for yes as the parameter to define
+	echo whether you want to receive the abp_style values in the megalist.
+	echo e.g.
+	echo ./MegaList.sh y
+	echo or
+	echo ./MegaList.sh n
+	echo it also works to start the script without parameters.
+	echo Without parameter also means "n"
+	exit 1
+fi
+
 function cleanup() {
 	rm $linkfile
 	rm $blocklistfile-*.txt


### PR DESCRIPTION
Die Änderungen des Scriptes von @Sonnenalle aus pullrequest #1141, finden ich soweit in Ordnung.
Ich habe in diesen Pull Request seine Änderungen mit eingeflossen und zusätzlich noch folgenden Code hinzugefügt:
```
if [ "$abp_style" != "y" ] && [ "$abp_style" != "n" ]; then
	echo please enter "n" for no or "y" for yes as the parameter to define
	echo whether you want to receive the abp_style values in the megalist.
	echo e.g.
	echo ./MegaList.sh y
	echo or
	echo ./MegaList.sh n
	echo it also works to start the script without parameters.
	echo Without parameter also means "n"
	exit 1
fi
```

Der Abschnitt prüft ob in der Variable. z.b. wenn man ./MegaList.sh y oder ./MegaList.sh n eingegeben hat.
Es prüft auch das man nichts anderes als y oder n eingeben kann damit wenn der Benutzer z.b. ./MegaList.sh g  oder ähnliches (und damit keinen definierten Wert) eingibt, das das Script darauf hinweist.
Desweiteren ist es ohne Probleme möglich das Script ohne parameter (also ohne was dahinter z.b. y oder n) auszuführen.