### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,9 +1,9 @@
-name: "Issue and Pull request Labeler"
+name: "Issue Labeler"
 on:
   issues:
     types: [opened, edited]
-  pull_request:
-    types: [opened, edited]
+#  pull_request:
+#    types: [opened, edited]
 
 permissions:
   contents: read
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
+#      pull-requests: write
       
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This removes the automatic labeling of pull requests because something doesn't seem to work there.

An error has already been documented under the link: https://github.com/RPiList/specials/actions/runs/5508828312