### PR TITLE
Update Blocklisten.md

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -385,6 +385,8 @@ https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/child-prot
 
 https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/proxies
 
+https://nsfw.oisd.nl
+
 
 # Fakeshops und Abofallen
 
@@ -548,7 +550,7 @@ https://www.einmalzahlungzweihundert.de/bl-einmalzahlung.txt
 
 # Diverse
 
-https://dbl.oisd.nl/
+https://big.oisd.nl
 
 https://v.firebog.net/hosts/static/w3kbl.txt
 


### PR DESCRIPTION
- Domain Update:
The domain "https://dbl.oisd.nl/" has been changed to "https://big.oisd.nl/". This change was necessary because the newer domain, "https://big.oisd.nl/", utilizes the ABP syntax, whereas the old domain will no longer be supported starting from January 1, 2024.

- Category Addition:
I have added "https://nsfw.oisd.nl/" to the "Jugendschutz" (youth protection) category in the Blocklists.md file. This blocklist is a combination of more than 40 lists for porn/shock/adult sites.