### PR TITLE
Instructions for installing pihole via docker compose

### DIFF
--- a/Anleitungen/install-pihole.md
+++ b/Anleitungen/install-pihole.md
@@ -127,6 +127,21 @@ docker-compose up -d
 Quellen: [Docker](https://docs.docker.com/engine/install/debian/#install-using-the-convenience-script); [Pihole](https://github.com/pi-hole/docker-pi-hole#quick-start)
 
 #### Hinweise
+- Wo ist das Passwort für das Pihole?
+
+Der Pihole Container generiert sich ein eigenes Zufallspasswort.
+Das Passwort kann wie folgt geändert werden:
+
+```bash
+# Bis Pihole Version 5
+docker exec -it pihole pihole -a -p
+```
+
+```bash
+# Ab Pihole Version 6
+docker exec -it pihole pihole setpassword
+```
+
 - Der Pihole Container sollte hin und wieder aktualisiert werden
 
 ```bash

--- a/Anleitungen/install-pihole.md
+++ b/Anleitungen/install-pihole.md
@@ -19,19 +19,19 @@ systemctl disable systemd-resolved
 systemctl stop systemd-resolved
 ```
 
-Fügen Sie dann die folgende Zeile in den Abschnitt [main] Ihrer /etc/NetworkManager/NetworkManager.conf ein:
+3. Fügen Sie dann die folgende Zeile in den Abschnitt [main] Ihrer /etc/NetworkManager/NetworkManager.conf ein:
 
 ```
 dns=default
 ```
 
-Löschen Sie den Symlink /etc/resolv.conf
+4. Löschen Sie den Symlink /etc/resolv.conf
 
 ```bash
 rm /etc/resolv.conf
 ```
 
-Starte NetworkManager neu
+5. Starte NetworkManager neu
 
 ```bash
 systemctl restart NetworkManager

--- a/Anleitungen/install-pihole.md
+++ b/Anleitungen/install-pihole.md
@@ -1,22 +1,64 @@
-## Installation von Pihole für Raspberry Pi (gilt auch für VMs und Thin Clients)
+## Installation von Pihole für Raspberry Pi, VMs und Thin Clients
 
 #### Hinweise vorab
-- bei Ubuntu Systemen muss der Systemctl resolve deaktiviert werden um den Port 53 nutzen zu können
-
-  - Beschreibung folgt
-
-
-### Installation von Docker und Pihole über Docker compose
+<details>
+  <summary>- Bei Ubuntu Systemen muss der Systemctl resolve deaktiviert werden um den Port 53 nutzen zu können</summary>
 
 1. Root Shell erlangen
 
-- Als Root anmelden oder als User folgendes eingeben um auf die Root Shell zu kommen
+- Als Root anmelden oder als User folgendes eingeben, um auf die Root Shell zu kommen
 
 ```bash
 sudo -s
 ```
 
-2. Docker und Docker-compose installieren
+2. Deaktivieren und stoppen Sie den systemd-aufgelösten Dienst:
+
+```bash
+systemctl disable systemd-resolved
+systemctl stop systemd-resolved
+```
+
+Fügen Sie dann die folgende Zeile in den Abschnitt [main] Ihrer /etc/NetworkManager/NetworkManager.conf ein:
+
+```
+dns=default
+```
+
+Löschen Sie den Symlink /etc/resolv.conf
+
+```bash
+rm /etc/resolv.conf
+```
+
+Starte NetworkManager neu
+
+```bash
+systemctl restart NetworkManager
+```
+
+Quelle: [askubuntu.com](https://askubuntu.com/questions/907246/how-to-disable-systemd-resolved-in-ubuntu)
+</details>
+
+### Installation von Docker und Pihole über Docker compose
+
+1. Root Shell erlangen
+
+- Als Root anmelden oder als User folgendes eingeben, um auf die Root Shell zu kommen
+
+```bash
+sudo -s
+```
+
+2. System aktualisieren
+
+- Das System (Debian und Ubuntu) auf den neusten stand bringen
+
+```bash
+apt update && apt upgrade -y && apt autoremove -y
+```
+
+3. Docker und Docker-compose installieren
 
 - Docker installieren (Debian und Ubuntu)
 
@@ -32,7 +74,7 @@ ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
 ```
 
-3. Pihole über Docker-compose installieren
+4. Pihole über Docker-compose installieren
 
 - Erstelle einen neuen Ordner und erstelle in den neuen Ordner eine docker-compose.yml
 
@@ -45,7 +87,7 @@ cd ~/server/docker/pihole
 nano docker-compose.yml
 ```
 
-- In den "nano" Fenster dann folgenden Inhalt rein kopieren
+- In den "nano" Fenster dann folgenden Inhalt reinkopieren
 
 ```yaml
 version: "3"
@@ -62,6 +104,7 @@ services:
       - "67:67/udp" # DHCP server
       - "80:80/tcp" # Webserver
     volumes:
+      # Volume mount for pihole userdata
       - './etc-pihole:/etc/pihole'
       - './etc-dnsmasq.d:/etc/dnsmasq.d'
       # Sync Timezone
@@ -71,18 +114,20 @@ services:
     restart: unless-stopped
 ```
 
-- Dann den Inhalt speichern mit strg + O-Taste dann Enter und dann Strg + X-Taste zum verlassen
+- Dann den Inhalt speichern mit Strg + O-Taste dann Enter und dann Strg + X-Taste zum Verlassen
 
-- Dann den Container starten mit folgenden Befehl
+- Dann den Container starten mit folgendem Befehl
 
 ```bash
-docker-compose up - d
+docker-compose up -d
 ```
 
-- Das Pihole ist nun über die ip Adresse des Gerätes und den in der compose file angegebenen Port (Webserver) erreichbar
+- Das Pihole ist nun über die IP-Adresse des Gerätes und den in der compose file angegebenen Port (Webserver) erreichbar
+
+Quellen: [Docker](https://docs.docker.com/engine/install/debian/#install-using-the-convenience-script); [Pihole](https://github.com/pi-hole/docker-pi-hole#quick-start)
 
 #### Hinweise
-- der Pihole Container sollte hin und wieder aktualisiert werden
+- Der Pihole Container sollte hin und wieder aktualisiert werden
 
 ```bash
 cd ~/server/docker/pihole
@@ -90,6 +135,6 @@ docker-compose pull
 docker-compose up -d
 ```
 
-- Ein automatisches update über Watchtower ist auch möglich
+- Ein automatisches Update über Watchtower ist auch möglich
 
 [Installation von Watchtower](https://youtu.be/6EujFKzsvvA)

--- a/Anleitungen/install-pihole.md
+++ b/Anleitungen/install-pihole.md
@@ -1,0 +1,95 @@
+## Installation von Pihole für Raspberry Pi (gilt auch für VMs und Thin Clients)
+
+#### Hinweise vorab
+- bei Ubuntu Systemen muss der Systemctl resolve deaktiviert werden um den Port 53 nutzen zu können
+
+  - Beschreibung folgt
+
+
+### Installation von Docker und Pihole über Docker compose
+
+1. Root Shell erlangen
+
+- Als Root anmelden oder als User folgendes eingeben um auf die Root Shell zu kommen
+
+```bash
+sudo -s
+```
+
+2. Docker und Docker-compose installieren
+
+- Docker installieren (Debian und Ubuntu)
+
+```bash
+curl -sSL https://get.docker.com | bash
+```
+
+- Docker compose installieren
+
+```bash
+curl -SL $(curl -L -s https://api.github.com/repos/docker/compose/releases/latest | grep -o -E "https://(.*)docker-compose-linux-$(uname -m)") -o /usr/local/bin/docker-compose
+ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+```
+
+3. Pihole über Docker-compose installieren
+
+- Erstelle einen neuen Ordner und erstelle in den neuen Ordner eine docker-compose.yml
+
+```bash
+mkdir ~/server/docker/pihole -p
+cd ~/server/docker/pihole
+```
+
+```bash
+nano docker-compose.yml
+```
+
+- In den "nano" Fenster dann folgenden Inhalt rein kopieren
+
+```yaml
+version: "3"
+
+# More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
+services:
+  pihole:
+    container_name: pihole
+    image: pihole/pihole:latest
+    # For DHCP it is recommended to remove these ports and instead add: network_mode: "host"
+    ports:
+      - "53:53/tcp" # DNS
+      - "53:53/udp" # DNS
+      - "67:67/udp" # DHCP server
+      - "80:80/tcp" # Webserver
+    volumes:
+      - './etc-pihole:/etc/pihole'
+      - './etc-dnsmasq.d:/etc/dnsmasq.d'
+      # Sync Timezone
+      - '/etc/timezone:/etc/timezone:ro'
+    cap_add:
+      - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
+    restart: unless-stopped
+```
+
+- Dann den Inhalt speichern mit strg + O-Taste dann Enter und dann Strg + X-Taste zum verlassen
+
+- Dann den Container starten mit folgenden Befehl
+
+```bash
+docker-compose up - d
+```
+
+- Das Pihole ist nun über die ip Adresse des Gerätes und den in der compose file angegebenen Port (Webserver) erreichbar
+
+#### Hinweise
+- der Pihole Container sollte hin und wieder aktualisiert werden
+
+```bash
+cd ~/server/docker/pihole
+docker-compose pull
+docker-compose up -d
+```
+
+- Ein automatisches update über Watchtower ist auch möglich
+
+[Installation von Watchtower](https://youtu.be/6EujFKzsvvA)

--- a/Download.md
+++ b/Download.md
@@ -32,8 +32,6 @@
 ### Weitere Download-Quellen:
 - https://heldendesbildschirms.de/download/software/betriebssysteme/svpihole/
 
-- https://ipfs.io/ipfs/Qmab2Pc3pxrLqpt18JWmVvUbVptKKqaNBSevWiezgHVMkw?filename=svpihole2212.zip
-
 #### Häufig gestellte Frage:
 Worin besteht der Unterschied zur Vorversion?
 Die Version 2010 nutzt die neue Gruppenfunktion des Pi-hole 5. Die Voreinstellung bestimmt dass die Listen zum Schutz von Minderjährigen (Glückspiel/FSK18-Seiten usw...) für den Standard-Nutzer gelten. Möchte ein Nutzer auf die zuvor genannten Seiten zugreifen, schiebt er seinen PC/Tablet in die Nutzergruppe "Adults". Eine ausführliche Erläuterung finden Sie hier: https://youtu.be/_Jj4Jv1s_hE

--- a/Download.md
+++ b/Download.md
@@ -1,7 +1,11 @@
 # Aktuelle Version
 
+## Raspberry Pi, VMs und Thin Clients:
+- [Installation von Pihole über docker-compose (Schriftliche Anleitung)](./Anleitungen/install-pihole.md)
 
-## Raspberry Pi:
+<details>
+  <summary>SVPihole Image für Raspberry Pi (deprecated)</summary>
+
 - http://o1.sempervideo.de/svpihole2212.zip
 
 - http://o2.sempervideo.de/svpihole2212.zip
@@ -33,13 +37,14 @@
 #### Häufig gestellte Frage:
 Worin besteht der Unterschied zur Vorversion?
 Die Version 2010 nutzt die neue Gruppenfunktion des Pi-hole 5. Die Voreinstellung bestimmt dass die Listen zum Schutz von Minderjährigen (Glückspiel/FSK18-Seiten usw...) für den Standard-Nutzer gelten. Möchte ein Nutzer auf die zuvor genannten Seiten zugreifen, schiebt er seinen PC/Tablet in die Nutzergruppe "Adults". Eine ausführliche Erläuterung finden Sie hier: https://youtu.be/_Jj4Jv1s_hE
+</details>
 
 -----
 
 ## Synology Diskstation:
--  [Installation von Pihole über docker-compose](https://www.youtube.com/watch?v=dZKDlfqXRuc)
+-  [Installation von Pihole über docker-compose (Video)](https://www.youtube.com/watch?v=dZKDlfqXRuc)
 
-#### [Synology Modelle die Docker unterstützen](https://www.youtube.com/watch?v=2X1vrnZBpzc):
+#### [Synology Modelle die Docker unterstützen (Video)](https://www.youtube.com/watch?v=2X1vrnZBpzc):
 | Serie    | Modelle                                                                                                                   |
 |:--------:|:-------------------------------------------------------------------------------------------------------------------------:|
 | Serie 10 | RS810RP+, RS810+, DS1010+, DS710+                                                                                         |


### PR DESCRIPTION
This adds a new guide to the "Anleitungen" folder where I created this written guide to installing pihole via docker-compose on an rpi, vm and thinclient.

There is also a link to it in the download.md and the things about the svpihole image are placed on a spoiler and the broken ipfs link is removed

part of #1412