### PR TITLE
add hopp.bio to whitelist

### DIFF
--- a/dev/whitelist
+++ b/dev/whitelist
@@ -1146,6 +1146,7 @@ homebank.ro
 homedepot.com
 hootsuite.com
 hopin.com
+hopp.bio
 hopp.to
 hosts-file.net
 hotmail.com

--- a/dev/whitelist
+++ b/dev/whitelist
@@ -3982,6 +3982,7 @@ www.homebank.ro
 www.homedepot.com
 www.hootsuite.com
 www.hopin.com
+www.hopp.bio
 www.hopp.to
 www.hosts-file.net
 www.hotstar.com


### PR DESCRIPTION
Hey, 

Please add hopp.bio to the whitelist. It is another domain for hopp.to that is already in the whitelist. 

https://github.com/RPiList/specials/issues/1434

Thanks