### PR TITLE
Fix Typos on Template/readme.md

### DIFF
--- a/Template/readme.md
+++ b/Template/readme.md
@@ -1,3 +1,3 @@
-## Dies ist das Template Verzeichnis was das Template für automatisch generierte *.md Dateien enthält.
+## Dies ist das Template Verzeichnis, was das Template für automatisch generierten *.md Dateien enthält.
 
-Manuelle Änderungen zur *.md Datei nur am Template ändern da das Script es in der Original Datei ohnehin überschreibt.
+Manuelle Änderungen zur *.md Datei nur am Template ändern, da das [Script](.github/scripts) es in der Originaldatei ohnehin überschreibt.


### PR DESCRIPTION
This fixes typos in the above file

The typos come from my commit df58ce8348d2ecde225f4d89202eaadc558ffe33 From the file mentioned above (in the subject).