### PR TITLE
Create Whitelist.md

### DIFF
--- a/Whitelist.md
+++ b/Whitelist.md
@@ -1,0 +1,7 @@
+# Whitelists zur Ergänzung nach eigenem Ermessen. Die Listen stammen teilweise von Dritten und können daher nicht auf Richtigkeit geprüft werden. Doppelnennungen möglich. 
+ 
+# Eigene Listen (Copy & Paste): 
+ 
+```
+https://github.com/LizenzFass78851/RPiList_specials/raw/master/dev/whitelist
+```


### PR DESCRIPTION
This creates a Whitelist.md so you can use it to list your own whitelists. Similar to Blocklisten.md. (This Whitelist.md is not included in this github workflow and can therefore be changed directly after the merge).

Only the whitelist from the “dev” area can be found in the md file.