### PR TITLE
Update Blocklisten.md (über das Template)

### DIFF
--- a/Template/Blocklisten.md/02
+++ b/Template/Blocklisten.md/02
@@ -176,5 +176,4 @@ https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telem
 https://raw.githubusercontent.com/wlqY8gkVb9w1Ck5MVD4lBre9nWJez8/W10TelemetryBlocklist/master/W10TelemetryBlocklist 
 https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt 
 https://raw.githubusercontent.com/jmdugan/blocklists/master/corporations/facebook/all 
-https://raw.githubusercontent.com/ChefTyler/MiscHostsFiles/master/ChanBlocker.txt
 ```


### PR DESCRIPTION
Dies entfernt einen nicht mehr existierenden Link aus den [Template der Blocklisten.md](https://github.com/RPiList/specials/blob/master/Template/Blocklisten.md).
Diese Änderung wird wie gewohnt durch den [Github Workflow](https://github.com/RPiList/specials/actions/workflows/gen_blocklisten.md.yml) automatisch am nächsten Tag in die richtige [Blocklisten.md](https://github.com/RPiList/specials/blob/master/Blocklisten.md) übernommen.

Der Link der nicht mehr exisiert ist:
`https://raw.githubusercontent.com/ChefTyler/MiscHostsFiles/master/ChanBlocker.txt`