### PR TITLE
Update install-pihole.md

### DIFF
--- a/Anleitungen/install-pihole.md
+++ b/Anleitungen/install-pihole.md
@@ -69,9 +69,9 @@ curl -sSL https://get.docker.com | bash
 - `docker-compose` installieren
 
 ```bash
-curl -SL $(curl -L -s https://api.github.com/repos/docker/compose/releases/latest | grep -o -E "https://(.*)docker-compose-linux-$(uname -m)") -o /usr/local/bin/docker-compose
-ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
+echo -e '#!/bin/sh\nexec docker compose "$@"' | tee /usr/local/bin/docker-compose && \
+  ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose && \
+  chmod +x /usr/local/bin/docker-compose
 ```
 
 4. `pihole` über `docker-compose` installieren


### PR DESCRIPTION
This updates the above-mentioned guide to make a change so that docker-compose is no longer installed standalone, but instead allows it to be installed as a pzeudo symlink to `docker compose` in order to use `docker-compose` and `docker compose` without any additional effort. Because in some cases the older command `docker-compose` is still very common in scripts or when running it yourself.