### PR TITLE
Update Streaming Blocklist

### DIFF
--- a/Blocklisten/Streaming
+++ b/Blocklisten/Streaming
@@ -4936,7 +4936,6 @@
 ||eadrama.to^
 ||easywatchanimemovie.com^
 ||ebaflix.de^
-||ebay.com^
 ||ed-protect.org^
 ||edelflix.de^
 ||edofilms.de^


### PR DESCRIPTION
this removes `ebay.com` from the list because it is a false positive.

this fixes #1519

I don't want to get ahead of anyone, but I still wanted to contribute something to this situation.