### PR TITLE
[just a idea] add Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/RPiList/specials/discussions
+    about: If you have ideas, ask questions and would like to have them answered and would like to show and tell something. then join the discussions

--- a/.github/ISSUE_TEMPLATE/entry_request.yml
+++ b/.github/ISSUE_TEMPLATE/entry_request.yml
@@ -1,0 +1,21 @@
+name: New domains to blocklists
+description: Report a new domain entry to blocklists so that it is included in the blocklists.
+title: 'entry_request: `replace-with-your-domain-entry.url`'
+labels: ['enhancement']
+body:
+  - type: textarea
+    attributes:
+      label: Domain(s)
+      description: |
+        - Describe which domains should be included in the block lists
+        - (domain entry per line)
+      render: shell
+    validations:
+        required: true
+  - type: textarea
+    attributes:
+      label: Reason
+      description: For what reason should the domains be included in the block lists?
+    validations:
+        required: true
+

--- a/.github/ISSUE_TEMPLATE/entry_request.yml
+++ b/.github/ISSUE_TEMPLATE/entry_request.yml
@@ -1,21 +1,29 @@
-name: New domains to blocklists
-description: Report a new domain entry to blocklists so that it is included in the blocklists.
-title: 'entry_request: `replace-with-your-domain-entry.url`'
+name: New Domains to Blocklists
+description: Report a new Domain entry to Blocklists so that it is included in the Blocklists.
+title: 'entry_request: '
 labels: ['enhancement']
 body:
   - type: textarea
     attributes:
       label: Domain(s)
       description: |
-        - Describe which domains should be included in the block lists
-        - (domain entry per line)
+        - Describe which Domains should be included in the Blocklists
+        - (Domain entry per line)
       render: shell
+      placeholder: |
+        test.com
+        www.test.com
+        *.test.com
+        
+        testing.org
+        www.testing.org
+        *.testing.org
     validations:
         required: true
   - type: textarea
     attributes:
       label: Reason
-      description: For what reason should the domains be included in the block lists?
+      description: For what reason should the Domains be included in the Blocklists?
     validations:
         required: true
 

--- a/.github/ISSUE_TEMPLATE/false_positive.yml
+++ b/.github/ISSUE_TEMPLATE/false_positive.yml
@@ -1,0 +1,28 @@
+name: False positive domains on blocklists
+description: Report a false positive domain entry on blocklists.
+title: 'false-positive: `replace-with-your-domain-entry.url`'
+labels: ['false-positive']
+body:
+  - type: textarea
+    attributes:
+      label: Domain(s)
+      description: |
+        - specify which domain entries are blocked 
+        - (domain entry per line)
+      render: shell
+    validations:
+        required: true
+  - type: textarea
+    attributes:
+      label: Reason
+      description: state why it is a false positive entry
+    validations:
+        required: true
+  - type: textarea
+    attributes:
+      label: Which blocklists
+      description: |
+        - [optional]
+        - specifies where the domains are blocked by which block lists (e.g. domainsquatting)
+        - This can also be read out via the pihole
+

--- a/.github/ISSUE_TEMPLATE/false_positive.yml
+++ b/.github/ISSUE_TEMPLATE/false_positive.yml
@@ -1,28 +1,42 @@
-name: False positive domains on blocklists
-description: Report a false positive domain entry on blocklists.
-title: 'false-positive: `replace-with-your-domain-entry.url`'
+name: False positive Domains on Blocklists
+description: Report a false positive Domain entry on Blocklists.
+title: 'false-positive: '
 labels: ['false-positive']
 body:
   - type: textarea
     attributes:
       label: Domain(s)
       description: |
-        - specify which domain entries are blocked 
+        - Specify which Domain entries are blocked 
         - (domain entry per line)
       render: shell
+      placeholder: |
+        test.com
+        www.test.com
+        *.test.com
+        
+        testing.org
+        www.testing.org
+        *.testing.org
     validations:
         required: true
   - type: textarea
     attributes:
       label: Reason
-      description: state why it is a false positive entry
+      description: State why it is a false positive entry
     validations:
         required: true
   - type: textarea
     attributes:
       label: Which blocklists
       description: |
-        - [optional]
-        - specifies where the domains are blocked by which block lists (e.g. domainsquatting)
-        - This can also be read out via the pihole
+        - [Optional]
+        - Specifies where the Domains are blocked by which Blocklists (e.g. DomainSquatting)
+        - This can also be read out via the Pihole 
+      render: shell
+      placeholder: |
+        Exact match for test.com found in:
+         - https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
+        Exact match for www.test.com found in:
+         - https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware
 


### PR DESCRIPTION
This creates an issue template with the possibility of reporting false positive domains and reporting domains for addition to the block lists to unify. In addition, the possibility of discussions is also mentioned here and blank issues are still permitted.

This pull request is just an idea. If many people don't like it because it provides the issues with templates, then please don't merge this pull request.

This is what it would look like if you click on the “issue” tab. You then get the choice and the option to continue creating “blank issues”:
![Screenshot](https://github.com/RPiList/specials/assets/82592556/658ac7b4-3abc-4422-bc42-852b6d9727a8)

You can see what the template itself looks like there:
- https://github.com/LizenzFass78851/RPiList_specials/blob/issue_template/.github/ISSUE_TEMPLATE/false_positive.yml
- https://github.com/LizenzFass78851/RPiList_specials/blob/issue_template/.github/ISSUE_TEMPLATE/entry_request.yml