### PR TITLE
Update `gen_md_files.yml`

### DIFF
--- a/.github/workflows/gen_md_files.yml
+++ b/.github/workflows/gen_md_files.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   generate-and-deploy:
     container:
-      image: ubuntu:22.04
+      image: ubuntu:24.04
     runs-on: ubuntu-latest
     if: github.repository == 'RPiList/specials'
 


### PR DESCRIPTION
This updates the container image used to Ubuntu 24.04.
The workflow continues to work afterwards, as can be seen there:
https://github.com/LizenzFass78851/RPiList_specials/actions/runs/9138646157