### PR TITLE
Update `Unbound.md`

### DIFF
--- a/Unbound.md
+++ b/Unbound.md
@@ -1,4 +1,116 @@
-**Anleitung**
+## Anleitung
 
 https://docs.pi-hole.net/guides/unbound/
 
+-----
+
+## Docker Variante
+
+
+<details>
+  <summary>mit Pihole Version 5</summary>
+
+```yaml
+version: '2'
+
+services:
+  pihole:
+    container_name: pihole
+    image: pihole/pihole:2024.05.0 # <- update image version here, see: https://github.com/pi-hole/docker-pi-hole/releases
+    ports:
+      - 53:53/tcp   # DNS
+      - 53:53/udp   # DNS
+      - 80:80/tcp   # HTTP
+      - 443:443/tcp # HTTPS
+    environment:
+      # Standardangaben
+      - FTLCONF_LOCAL_IPV4=<IP-Adresse von Docker Host>
+      - TZ=Europe/Berlin
+      - WEBPASSWORD=<Hier das Passwort eintragen>
+      # Für das Lokale erreichen der Geräte unter der Domain des Routers (z.B. fritz.box
+      - REV_SERVER=
+      - REV_SERVER_TARGET=
+      - REV_SERVER_DOMAIN=
+      - REV_SERVER_CIDR=
+      # Verbindung zu Unbound
+      - PIHOLE_DNS_=unbound # Hardcoded to our Unbound server
+      - DNSSEC=true # Enable DNSSEC
+    volumes:
+      - etc_pihole:/etc/pihole:rw
+      - etc_pihole_dnsmasq:/etc/dnsmasq.d:rw
+    networks:
+      - pihole-unbound
+    restart: unless-stopped
+    depends_on:
+      - unbound
+
+  unbound:
+    container_name: unbound
+    image: mvance/unbound:latest
+    networks:
+      - pihole-unbound
+    restart: unless-stopped
+
+networks:
+  pihole-unbound:
+
+volumes:
+  etc_pihole:
+  etc_pihole_dnsmasq:
+```
+
+</details>
+
+
+<details>
+  <summary>mit Pihole Version 6</summary>
+
+```yaml
+version: '2'
+
+services:
+  pihole:
+    container_name: pihole
+    image: pihole/pihole:development-v6 # <- update image version here, see: https://github.com/pi-hole/docker-pi-hole/releases
+    ports:
+      - 53:53/tcp   # DNS
+      - 53:53/udp   # DNS
+      - 80:80/tcp   # HTTP
+      - 443:443/tcp # HTTPS
+    environment:
+      # Standardangaben
+      - TZ=Europe/Berlin
+      - FTLCONF_webserver_api_password=<Hier das Passwort eintragen>
+      # Für das Lokale erreichen der Geräte unter der Domain des Routers (z.B. fritz.box
+      - FTLCONF_dns_revServers=
+      # Verbindung zu Unbound
+      - FTLCONF_dns_upstreams=unbound # Hardcoded to our Unbound server
+      - FTLCONF_dns_dnssec=true # Enable DNSSEC
+    volumes:
+      - etc_pihole:/etc/pihole:rw
+      - etc_pihole_dnsmasq:/etc/dnsmasq.d:rw
+    networks:
+      - pihole-unbound
+    restart: unless-stopped
+    depends_on:
+      - unbound
+
+  unbound:
+    container_name: unbound
+    image: mvance/unbound:latest
+    networks:
+      - pihole-unbound
+    restart: unless-stopped
+
+networks:
+  pihole-unbound:
+
+volumes:
+  etc_pihole:
+  etc_pihole_dnsmasq:
+```
+
+</details>
+
+Quelle:
+https://discourse.pi-hole.net/t/pihole-v6-unbound-in-one-docker-container/70091/5


### PR DESCRIPTION
Since the `docker-pihole-unbound` topic is still on my mind and I don't know how I can publish this information about the successful construction of the 2-container solution, I have the idea of ​​writing it in the `unbound.md`. (if that's OK)
I have written the working examples of the `docker-compose.yml` for pihole v5 and v6 in there. 
Based on the following discussion https://github.com/RPiList/specials/discussions/1542#discussioncomment-9381295 and another pull request https://github.com/RPiList/MyDockerCompose/pull/6
