### PR TITLE
Update Unbound.md

### DIFF
--- a/Unbound.md
+++ b/Unbound.md
@@ -16,7 +16,7 @@ version: '2'
 services:
   pihole:
     container_name: pihole
-    image: pihole/pihole:2024.05.0 # <- update image version here, see: https://github.com/pi-hole/docker-pi-hole/releases
+    image: pihole/pihole:2024.06.0 # <- update image version here, see: https://github.com/pi-hole/docker-pi-hole/releases
     ports:
       - 53:53/tcp   # DNS
       - 53:53/udp   # DNS


### PR DESCRIPTION
small version adaptation for the instructions

**edit:** This change is required for using pihole on x86 CPUs because the developers of pihole have fixed the problem. See https://github.com/pi-hole/docker-pi-hole/compare/2024.05.0...2024.06.0