### PR TITLE
text correction in `.github/markdown_templates/readme.md`

### DIFF
--- a/.github/markdown_templates/readme.md
+++ b/.github/markdown_templates/readme.md
@@ -1,3 +1,3 @@
 ## Dies ist das Template Verzeichnis, was das Template für automatisch generierten *.md Dateien enthält.
 
-Manuelle Änderungen zur *.md Datei nur am Template ändern, da das [Script](.github/scripts) es in der Originaldatei ohnehin überschreibt.
+Manuelle Änderungen zur *.md Datei nur am Template ändern, da das [Script](../scripts) es in der Originaldatei ohnehin überschreibt.


### PR DESCRIPTION
fixes a text error when linking to a directory