### PR TITLE
optimize github workflow to generate *.md files

### DIFF
--- a/.github/workflows/gen_md_files.yml
+++ b/.github/workflows/gen_md_files.yml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE
-          git clone https://github-actions:$GITHUB_TOKEN@${GITHUB_SERVER_URL##*/}/$GITHUB_REPOSITORY.git $GITHUB_WORKSPACE --branch $GITHUB_REF_NAME  --single-branch
+          git clone https://github-actions:$GITHUB_TOKEN@${GITHUB_SERVER_URL##*/}/$GITHUB_REPOSITORY.git $GITHUB_WORKSPACE --branch $GITHUB_REF_NAME --depth=1 --single-branch
 
       - name: generate
         run: |


### PR DESCRIPTION
this optimizes the github workflow for generating the selected *.md files.

Optimize the clone step used in the workflow to reduce the length of the workflow runtime because the size of the repo is so large that the complete cloning in the workflow is unnecessary and therefore only clones the part with the latest commit and thus the current state, which is sufficient for the commit step of the workflow.

A reduction from 15 to more than 5 minutes per run.

-----
Proof that the Github workflow still works after these changes can be seen there:
https://github.com/LizenzFass78851/RPiList_specials/actions/runs/11350784665