### PR TITLE
Update notserious list

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -82074,7 +82074,6 @@
 ||wearbreeze.co^
 ||wearbreeze.de^
 ||wearchild.com^
-||wearedevelopers.com^
 ||wearejaycobrand.com^
 ||wearejaycoshop.com^
 ||wearekinglife.com^


### PR DESCRIPTION
Die [wearedevelopers.com](https://www.wearedevelopers.com/) Website ist eine legitime Webseite einer Entwickler Konferenz. Der Eintag wurde aus der notserious Liste entfernt.