### PR TITLE
fix: remove sparda-h.de

### DIFF
--- a/Blocklisten/DomainSquatting/DE/sonstige_Banken/Sparda-Bank
+++ b/Blocklisten/DomainSquatting/DE/sonstige_Banken/Sparda-Bank
@@ -8806,7 +8806,6 @@
 ||sparda-f.de^
 ||sparda-g.de^
 ||sparda-gg.de^
-||sparda-h.de^
 ||sparda-hh.de^
 ||sparda-ib.de^
 ||sparda-j.de^


### PR DESCRIPTION
sparda-h.de is die offizielle Domain der Sparda-Bank Hannover.
Siehe z.B. https://www.sparda.de/ihr-weg-zu-uns-vor-ort/ -> Hannover