### PR TITLE
Remove unreachable digitalside list

### DIFF
--- a/Blocklisten.md
+++ b/Blocklisten.md
@@ -255,7 +255,6 @@ https://v.firebog.net/hosts/Prigent-Malware.txt
 https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt 
 https://raw.githubusercontent.com/Spam404/lists/master/adblock-list.txt 
 https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Risk/hosts 
-https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt 
 https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADomains.txt 
 https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt 
 https://raw.githubusercontent.com/FadeMind/hosts.extras/master/add.Spam/hosts 


### PR DESCRIPTION
Hi,
the [digitalside domain list](https://osint.digitalside.it/Threat-Intel/lists/latestdomains.txt) is offline since several months now and the [repository](https://github.com/davidonzo/Threat-Intel) hasn't been updated for a long time. See also davidonzo/Threat-Intel#51. The website [digitalside.it](https://www.digitalside.it/) shows a standard web page. Maybe it will be abandoned in the future or sold to someone else. 
I suggest to remove the list entirely.