### PR TITLE
Update `Unbound.md`

### DIFF
--- a/Unbound.md
+++ b/Unbound.md
@@ -32,7 +32,7 @@ services:
       # Siehe: https://github.com/pi-hole/docker-pi-hole?tab=readme-ov-file#optional-variables
       - FTLCONF_dns_revServers=
       # Verbindung zu Unbound
-      - FTLCONF_dns_upstreams=unbound#5053 # Hardcoded to our Unbound server
+      - FTLCONF_dns_upstreams=unbound#5335 # Hardcoded to our Unbound server
       - FTLCONF_dns_dnssec=true # Enable DNSSEC
     volumes:
       - etc_pihole:/etc/pihole:rw
@@ -45,10 +45,53 @@ services:
 
   unbound:
     container_name: unbound
-    image: crazymax/unbound:latest
+    image: alpinelinux/unbound:latest
     networks:
       - pihole-unbound
     restart: unless-stopped
+    post_start:
+      - command: |
+          sh -c "cat > /etc/unbound/unbound.conf << EOF
+          server:
+            verbosity: 0
+            interface: 0.0.0.0
+            port: 5335
+            do-ip4: yes
+            do-udp: yes
+            do-tcp: yes
+            do-ip6: no
+            prefer-ip6: no
+            harden-glue: yes
+            harden-dnssec-stripped: yes
+            use-caps-for-id: no
+            edns-buffer-size: 1232
+            prefetch: yes
+            num-threads: $(nproc 2>/dev/null || echo 1)
+            private-address: 192.168.0.0/16
+            private-address: 169.254.0.0/16
+            private-address: 172.16.0.0/12
+            private-address: 10.0.0.0/8
+            private-address: fd00::/8
+            private-address: fe80::/10
+            access-control: 10.0.0.0/8 allow
+            access-control: 127.0.0.0/8 allow
+            access-control: 172.16.0.0/12 allow
+            access-control: 192.168.0.0/16 allow
+            access-control: fd00::/8 allow
+            access-control: fe80::/10 allow
+            access-control: ::1/128 allow
+          EOF
+          until kill -HUP $(pidof unbound) >/dev/null 2>&1; do
+            sleep 1
+          done"
+    healthcheck:
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      test: >
+        CMD nslookup one.one.one.one 127.0.0.1:5335 >/dev/null 2>&1 || \
+            nslookup dns.google 127.0.0.1:5335 >/dev/null 2>&1 || \
+            exit 1
 
 networks:
   pihole-unbound:


### PR DESCRIPTION
This updates the `Unbound.md` file by using a different unbound image, which is more up-to-date than the previously specified unbound docker image.

[Alpine Linux](https://hub.docker.com/r/alpinelinux/unbound) (publisher of an Unbound image) has a more up-to-date Docker image than [Crazy Max's](https://hub.docker.com/r/crazymax/unbound).
[Crazy Max's](https://github.com/crazy-max/docker-unbound/releases) Docker image hasn't been updated with the latest version of [Unbound](https://nlnetlabs.nl/projects/unbound/about/) since October, and consequently, it's missing security fixes.