### PR TITLE
Remove de.mammotion.com false positive (issue #2483)

### DIFF
--- a/Blocklisten/notserious
+++ b/Blocklisten/notserious
@@ -21197,7 +21197,6 @@
 ||de.lucybreeze.com^
 ||de.lunaleder.com^
 ||de.mahertech24.com^
-||de.mammotion.com^
 ||de.markusdrueppel.com^
 ||de.mbm-cloudmining.eu^
 ||de.moravon.com^


### PR DESCRIPTION
Removes `de.mammotion.com` from `Blocklisten/notserious` (false positive, official shop of the Mammotion brand, per issue #2483).

**Changes**
- `Blocklisten/notserious`: 1 deletion (`||de.mammotion.com^`)

**Hinweis für den Maintainer**
Die Liste enthält weitere Mammotion-Einträge, die vermutlich denselben False-Positive-Hintergrund haben (regionale Ländershops desselben Herstellers):
`||mammotion.com^`, `||at.mammotion.com^`, `||au.mammotion.com^`, `||eu.mammotion.com^`, `||fr.mammotion.com^`, `||uk.mammotion.com^`, `||us.mammotion.com^`

Ich habe nur das gemeldete `de.mammotion.com` entfernt; ob die übrigen Einträge ebenfalls entfernt werden sollen, ist bewusst dem Maintainer überlassen.

Fixes #2483

---
*PR erstellt von einem automatisierten Agent (AincradBot).*
