### PR TITLE
Add spam and phishing domains (issues #2509, #2510)

### DIFF
--- a/Blocklisten/Phishing-Angriffe
+++ b/Blocklisten/Phishing-Angriffe
@@ -45461,6 +45461,7 @@
 ||dk7yrh2c7w.luslontril.xyz^
 ||dkapr2.com^
 ||dkapr3.com^
+||dkb-auth.de^
 ||dkb-de-kreditbank.baitalarablaundry.ae^
 ||dkb-erneuerung.info^
 ||dkb-im.com.es^
@@ -88176,6 +88177,7 @@
 ||nesufu.com^
 ||net-actifvillepro.com^
 ||net-actifvillepro.pro^
+||net-compliance-support.live^
 ||net-empresas-acessar.digital^
 ||net-flow.site^
 ||net-ledzerwallet.wixstudio.com^
@@ -118115,6 +118117,7 @@
 ||saklikoy.site^
 ||sakopreverm.com^
 ||saksuurunleri.com^
+||saktualisierung106.online^
 ||sakura-clubb.online^
 ||sakurarezidans.com^
 ||sakurholmen.top^
@@ -118638,6 +118641,7 @@
 ||sasjia.net^
 ||saskatoonautodetailing.com^
 ||sasoka.pro^
+||saspk.info^
 ||sassacesti.cyou^
 ||sassafras-bar.mom^
 ||sassere.fr^
@@ -121742,6 +121746,7 @@
 ||sicurezza-sella.it^
 ||sicyjyu.com^
 ||sidaun.com^
+||siddahmed.com^
 ||side-step.shop^
 ||sidecharts.com^
 ||sideifsiff.info^
@@ -130913,6 +130918,7 @@
 ||tawenu.world^
 ||tawercanos.rest^
 ||tawigua.com^
+||tawin.co^
 ||tawyxae.com^
 ||tax-bill.xyz^
 ||tax-filecenterccf9488af1d48a85307a32b4f739f2bb.lahmawy.com^
@@ -131121,6 +131127,7 @@
 ||techarch.us^
 ||techartadverts.com^
 ||techbase.site^
+||techbazaronline.co.uk^
 ||techbeyin.net^
 ||techbqv.com^
 ||techbroslop.com^
@@ -134427,6 +134434,7 @@
 ||thestingray.shop^
 ||thestitchandturn.shop^
 ||thestitchdown.shop^
+||thestitchingparlorinc.com^
 ||thestock-blast-pro.com^
 ||thestoryoflori.com^
 ||thestrapandsnap.shop^
@@ -141378,6 +141386,7 @@
 ||vcyvv.com^
 ||vd.agatakalinowska.cfd^
 ||vd5a0.com^
+||vdartinc.com^
 ||vdatvsa.com^
 ||vdclient.insofar.com^
 ||vdclient.ruthweinberg.com^
@@ -145857,6 +145866,7 @@
 ||vqjgs.com^
 ||vqqartlh.shop^
 ||vqqinegarish.business^
+||vr-online-konto-aktualisierung.cfd^
 ||vr-raiff.de^
 ||vr-spk-connect.digital^
 ||vr.aktualisierungid.info^

--- a/Blocklisten/spam.mails
+++ b/Blocklisten/spam.mails
@@ -381,6 +381,7 @@
 ||0nedrivpag.weebly.com^
 ||0nuyakzk81u.qwo231sdx.club^
 ||0nwihzvenvmgj.qwo231sdx.club^
+||0okgo54ur.purevbe.top^
 ||0olut8.cn^
 ||0opawll1rjda8qhn5llpxnb.qwo231sdx.club^
 ||0ow15sn0bqwf2.qwo231sdx.club^
@@ -457,7 +458,9 @@
 ||0x41c21693e60fc1a5dbb7c50e54e7a6016aa44c99.xyz^
 ||0xag4rc9u0.projects.webpages.one^
 ||0xgear.xyz^
+||0xuytir.markwjohnson.org^
 ||0xvideos.com^
+||0y5xfn19j0xth.primeessence.lol^
 ||0yb.com^
 ||0yc23773j8snsod18wyzku3c6r0m25.s3.fra.eu.cloud-object-storage.appdomain.cloud^
 ||0z.10bucksandchange.com^
@@ -1564,6 +1567,7 @@
 ||2fz2itpaen.liusanjie.cc^
 ||2g60fvzouvkp40rkj562muc3gxhyve.s3.mil.eu.cloud-object-storage.appdomain.cloud^
 ||2g86nc66.cikoza.net^
+||2gag3frqvb4a.glavinus.beer^
 ||2gfqe.qwo231sdx.club^
 ||2gkyvtsxfwvu.qwo231sdx.club^
 ||2gobud4amirjhydaats9eb7z86.liusanjie.cc^
@@ -2174,6 +2178,7 @@
 ||365oo365.com^
 ||365porno-onlain.net^
 ||365ppf.com^
+||365proplus.site^
 ||365qq365.com^
 ||365rr365.com^
 ||365shope.com^
@@ -2900,6 +2905,7 @@
 ||4te.fastappends.com^
 ||4theworld.tech.blog^
 ||4tmgedunatafucisr8dmxh.qwo231sdx.club^
+||4tpjg412s04s.photobooth.software^
 ||4tr.cc^
 ||4trq9v.43811.wap.shuaihu99.com^
 ||4u1mamfge.zrd13biz.win^
@@ -4032,6 +4038,7 @@
 ||6wqmo.qwo231sdx.club^
 ||6wz8sy.52131.wap.shuaihu99.com^
 ||6wzsoa0ove233vyqxk4y9zja4njf.qwo231sdx.club^
+||6x1h3ip.mindoasis.click^
 ||6xlqjg2tvviu4hpzuk.qwo231sdx.club^
 ||6xlxs2.hyperphp.com^
 ||6xup.kyojin.jp^
@@ -4316,6 +4323,7 @@
 ||7i0q9tjfnlvlibyowaccc.qwo231sdx.club^
 ||7i6llbnmd4mnz4ccil18r7.qwo231sdx.club^
 ||7i7pyfkgsp6ckn3rjejd6r7ke.qwo231sdx.club^
+||7idofkwwv40xm.aeromind.garden^
 ||7itroq.43811.wap.shuaihu99.com^
 ||7iwursv9ytsegyrdcxlbp4ir9zr.qwo231sdx.club^
 ||7izvkvhb.qwo231sdx.club^
@@ -4857,6 +4865,7 @@
 ||9dkxmcoqzomj4vo7s5lm-7tkzf1bmd7kemrhen3qk-pmieh12jmy2bzeigagm1.glitch.me^
 ||9e4fgx.40261.81935.m.shuaihu99.com^
 ||9ef642437a9299.lhr.life^
+||9ehmgg6y053nf5.regalbars.co.uk^
 ||9etvq92b.liusanjie.cc^
 ||9eu79dr8g7rqxampqbzzikiw23e.qwo231sdx.club^
 ||9f1zd1hotcgg0tk2q7ge8pqpdfs.qwo231sdx.club^
@@ -5580,6 +5589,7 @@
 ||a3l-2ns-e9w3.web.app^
 ||a3lthr.webwave.dev^
 ||a3n1ddxyhywdueff64rcw94zyqdahg.liusanjie.cc^
+||a3wwowq.ethnobalance.beer^
 ||a40452.actonservice.com^
 ||a40554.actonservice.com^
 ||a40587.actonservice.com^
@@ -6779,6 +6789,7 @@
 ||accountants.lk^
 ||accountantsvoordenonprofit.nl^
 ||accountappleid.com^
+||accountcassette.com^
 ||accounting.448connect.com^
 ||accounting.godberd.com^
 ||accounting.quuai.com^
@@ -7182,11 +7193,13 @@
 ||ad0be-westregion1.web.app^
 ||ad1.tone.ne.jp^
 ||ad2pym.mimo.run^
+||ad52.madeof.space^
 ||ad62785474.wixsite.com^
 ||ad632.astralholistics.com^
 ||ad6peiz8nvdmjumgfv.qwo231sdx.club^
 ||ad6pq0znleywzlxjrm4rugitnne20b.qwo231sdx.club^
 ||ad78.getlovematchnow.com^
+||ad870.madeof.space^
 ||ad959a81049456404.temporary.link^
 ||ad9lzvckoxo.qwo231sdx.club^
 ||ada-africa.org^
@@ -7884,6 +7897,7 @@
 ||aff.game.blog^
 ||affaires.cogeco.ca^
 ||affairlinois.com^
+||affecthurl.com^
 ||affectionate-mcclintock.199-223-114-249.plesk.page^
 ||affiliate.sexshop.cz^
 ||affiliateagencygroup.com^
@@ -8488,6 +8502,7 @@
 ||aitugg.com^
 ||aiu.kdda.263shx.cn^
 ||aiu.kdda.ex92.cn^
+||aiu69.cmpssc.com^
 ||aiuedu.org^
 ||aiuffass.com^
 ||aiufqcmojsinxou2m53lui.qwo231sdx.club^
@@ -9973,6 +9988,7 @@
 ||ami-508725962314.southamerica-east1.run.app^
 ||amiabghey.ru.com^
 ||amibr.com.br^
+||amicacs.co.ke^
 ||amicalesocietefrancaisevierzon.com^
 ||amichiganavenuemedicalcenter.com^
 ||amici.nz^
@@ -11334,6 +11350,7 @@
 ||apissolutions.co.nz^
 ||apiswisspass.cluster1.easy-hebergement.net^
 ||apitbullsparadise.com^
+||apitest-3ujr5vljnp.workers.dev^
 ||apitester.kurecka.cz^
 ||apitv.sistemaathos.com^
 ||apiurl.hs-sites.com^
@@ -14500,6 +14517,7 @@
 ||auto-macro.com^
 ||auto-mags.com^
 ||auto-mintt.com^
+||auto-notfallset.shop^
 ||auto-notif2022.firebaseapp.com^
 ||auto-notif2022.web.app^
 ||auto-profits.com^
@@ -15147,6 +15165,7 @@
 ||aw25.lentyfero.com^
 ||aw3jeb9ft50xnnxdcsbwv.qwo231sdx.club^
 ||aw5c01.webwave.dev^
+||awa49.tenfas.com^
 ||awa7-org.adventistfaith.org^
 ||awadephotography.com^
 ||awake-goldenrod-wrinkle.glitch.me^
@@ -15188,6 +15207,7 @@
 ||awhecti.com^
 ||awirer.com^
 ||awj7w-gyaaa-aaaad-qdcdq-cai.ic.fleek.co^
+||awl-zentrum.de^
 ||awmedical.com.pe^
 ||awnielhalhuli.sport.blog^
 ||awningsdc.com^
@@ -18378,6 +18398,7 @@
 ||beneficioparati.hostfree.pw^
 ||beneficios.davivienda.hn^
 ||beneficiotuyapay.hostfree.pw^
+||benefits.more2flirt.com^
 ||beneighbors.com^
 ||benelux.promo.skf.com^
 ||benevolent-brioche-2ec1bf.netlify.app^
@@ -19123,6 +19144,7 @@
 ||bforbank.click^
 ||bfry.xyz^
 ||bfsedu.com^
+||bft14.priney.space^
 ||bft5.destinia.fr^
 ||bft90f.webwave.dev^
 ||bfti.in^
@@ -19282,6 +19304,7 @@
 ||bhnrewards.com^
 ||bhomedecor.com^
 ||bhoocare.com^
+||bhp024.mytrex.space^
 ||bhphotovidoe.com^
 ||bhptd.cxtwczu.top^
 ||bhq1x8bimvvbnk67xriwuhitf.qwo231sdx.club^
@@ -23222,6 +23245,7 @@
 ||blogersakuno.com^
 ||blogexotique.com^
 ||blogf.onlineact1.site^
+||blogfreecookbook.com^
 ||blogg.maxipl-system.xyz^
 ||blogg.maxiprog.xyz^
 ||blogg.sexzone.se^
@@ -25226,6 +25250,7 @@
 ||bondagesporn.com^
 ||bondas-sa.com^
 ||bonded-salts.000webhostapp.com^
+||bondence.com^
 ||bondgroupe.com^
 ||bondikflas.xyz^
 ||bondistrip.com.au^
@@ -26643,6 +26668,7 @@
 ||bp2ycpoytjwchgv77ehcy09it9m.qwo231sdx.club^
 ||bp30trk.com^
 ||bp49289sc09a9994838cadic873.mire.tv^
+||bp71.derentyls.com^
 ||bp883.jashokin.com^
 ||bp88abub47.miltang.pl^
 ||bp8q8j.40261.81935.m.shuaihu99.com^
@@ -27496,6 +27522,7 @@
 ||brazzersfreeacounts.com^
 ||brb-ljubuski.com^
 ||brbd.com.cn^
+||brc8y6k.treehousefamilyadvisory.com^
 ||brcbeads.com^
 ||brcitykey.com^
 ||brcklink.com^
@@ -31585,6 +31612,7 @@
 ||buyteches.xyz^
 ||buyth.com.cn^
 ||buythebest.pw^
+||buyto.shop^
 ||buytoptrends.com^
 ||buyubozma.biz.tr^
 ||buyusasim.com^
@@ -32143,6 +32171,7 @@
 ||by3pf4.ictstartech.com^
 ||by79.xlny.my.id^
 ||by91.e-tipos.com^
+||byabj.olynatr-gnomem5565-99.xyz^
 ||byagency-interactive.com^
 ||byagote.top^
 ||byam.pw^
@@ -36936,6 +36965,7 @@
 ||casinosapproved.info^
 ||casinosbonus.eu^
 ||casinosbonuss.com^
+||casinosbonuss.net^
 ||casinoscusub-so.com^
 ||casinosdata-bangladesh.com^
 ||casinosdata.com^
@@ -38670,6 +38700,8 @@
 ||cdfqbh.xyz^
 ||cdfsafesecure29293.net^
 ||cdftapilauik.co.vu^
+||cdfvb.accountcassette.com^
+||cdfvb.affecthurl.com^
 ||cdgd.fu62q2.cn^
 ||cdgdenz.cn^
 ||cdgdircsb.oknijbuhg.us^
@@ -39266,6 +39298,7 @@
 ||ce4c3d3070efbadc4bdb7542ed42aa56.dopla.com.pl^
 ||ce548.thinksparkimpact.com^
 ||ce7168201c4.johncornell.com^
+||ce78.myloves.space^
 ||ce7yc7e7e-he89e-evue9u-eh939-e9ce.weebly.com^
 ||ce818263-d23c-4a3a-a098-cf040af0ffa2.medikamenterezeptfrei.biz^
 ||ce8hddosw1nkkgjo9cgv3.wusps.xyz^
@@ -44867,6 +44900,7 @@
 ||cirugiaplasticaandrescruz.com.mx^
 ||cirurgiamao.com^
 ||cis.asu.edu.eg^
+||cis485.myrule.space^
 ||cisasecure.com^
 ||cisb-dev.mit.edu^
 ||cisbd.org^
@@ -45297,6 +45331,7 @@
 ||citysmarty.com^
 ||citysquareresidences.onlinesrs.com^
 ||cityviewbrokers.com^
+||cityworking.com.br^
 ||cityzone.jetzt^
 ||citz-sms.info^
 ||citzenrest.com^
@@ -47173,6 +47208,8 @@
 ||clispackgeroute.com^
 ||clisscimb.top^
 ||clissold.com.au^
+||cliszs.accountcassette.com^
+||cliszs.affecthurl.com^
 ||cliten.microdoctor.com.br^
 ||clitisex.com^
 ||clitoridec.com^
@@ -47988,6 +48025,7 @@
 ||cmpf1a-gpps.co^
 ||cmpljh-uqqs.club^
 ||cmpns.com^
+||cmpssc.com^
 ||cmpyfh-uqqs.club^
 ||cmq.christinemcqueen.com.au^
 ||cmq.globprstar.online^
@@ -48463,6 +48501,7 @@
 ||co4e.yxzeam.digital^
 ||co663.ideaformsolve.us^
 ||co781.melunertesta.com^
+||co80.mytrex.space^
 ||co83083.tmweb.ru^
 ||co84143.tmweb.ru^
 ||co84916.tmweb.ru^
@@ -64016,6 +64055,7 @@
 ||cu82272.tmweb.ru^
 ||cu895.gamewizen.com^
 ||cu8ot7.webwave.dev^
+||cu93.myloves.space^
 ||cu96948.tmweb.ru^
 ||cuaca.anambaskab.go.id^
 ||cuacongtudong.net^
@@ -65142,6 +65182,7 @@
 ||cwovs.ga^
 ||cwp83.savannah-directory.net^
 ||cwpxjjguiilbdrqumw85x.qwo231sdx.club^
+||cwq747.chillj.com^
 ||cwqiveovpikwjtj3ynk8ue.liusanjie.cc^
 ||cwrecycler.com^
 ||cwrtzk.tk^
@@ -66009,6 +66050,7 @@
 ||d1fsr.ggjyia.id^
 ||d1gtyvks0eze5ebr.amuz.net.daraz.com^
 ||d1lu3pmaz2ilpx.monetiweb.net.zooplus.fr^
+||d1m6ved6xi.slowliving.beauty^
 ||d1nithdp88c3idz4alrcuj.wusps.xyz^
 ||d1nzb4nkk.net^
 ||d1pdzxzfd0f7higmsbv0bx0m.qwo231sdx.club^
@@ -66195,6 +66237,7 @@
 ||d5u8z3b2.stackpathcdn.com^
 ||d5xp5kpvy3agmnr.qwo231sdx.club^
 ||d5zcetrdgojzjqqj6u.lspower.xyz^
+||d613kcbv8wga.photobooth.software^
 ||d61a40fc.sibforms.com^
 ||d61bqafdgkzgrpzoruz.qwo231sdx.club^
 ||d623app.nstrcbas.com^
@@ -72704,6 +72747,7 @@
 ||deloitte227.net.daraz.com^
 ||deloittesupport.com^
 ||delolindo.es^
+||delonghi-kundenservice.de^
 ||delpakietpz.com^
 ||delphiassociates.org^
 ||delphilawadvisory.com^
@@ -75577,8 +75621,10 @@
 ||dk136acessorios.com.br^
 ||dk57br04.eu1.hs-sales-engage.com^
 ||dk57br04.eu1.hs-sales-sub.com^
+||dk858.madeof.space^
 ||dkajsdjiqwdwnfj.info^
 ||dkb-3905d.web.app^
+||dkb-auth.de^
 ||dkb-tanapp.jdevcloud.com^
 ||dkb.net.ph^
 ||dkb6.mil.ph^
@@ -75621,6 +75667,7 @@
 ||dlugoleka.pl^
 ||dluxxxedition.com^
 ||dluznik.cz^
+||dly53.priney.space^
 ||dlytdt.com^
 ||dm-cn.aliyuncs.com^
 ||dm020.kingdomsglory.com^
@@ -75688,6 +75735,7 @@
 ||dnu288.melunertesta.com^
 ||dnvr.net^
 ||dnw1-718340643432.us-central1.run.app^
+||dnw2-718340643432.us-central1.run.app^
 ||dnw3-718340643432.us-central1.run.app^
 ||dnw5-718340643432.us-central1.run.app^
 ||dnxtk.com^
@@ -75801,6 +75849,8 @@
 ||doingprinting.com^
 ||doingthethings.wtf^
 ||doingthis.fit^
+||dojhq.accountcassette.com^
+||dojhq.affecthurl.com^
 ||dojin-pandemic.com^
 ||dojo.jetzt^
 ||dojogirl.fashion.blog^
@@ -76441,6 +76491,7 @@
 ||dsntah.com^
 ||dso3bb.com^
 ||dsp-bifrost-tm.trafficmanager.net^
+||dsp028.kasiobask.com^
 ||dspk-sharapovo.internet01.ru^
 ||dspk-shishkino.ru^
 ||dspretargettraff.com^
@@ -76874,6 +76925,7 @@
 ||e4energy.solutions^
 ||e4f2z7h2.stackpathcdn.com^
 ||e4i7e7r3.stackpathcdn.com^
+||e4rv750gsv.primeessence.lol^
 ||e4v5s7g9.stackpathcdn.com^
 ||e506qd.vip^
 ||e51c.mara.gov.my^
@@ -76893,6 +76945,7 @@
 ||e6lbji9faj9fitlbw1ey.s3.ap-southeast-1.amazonaws.com^
 ||e6q4r7g2.stackpathcdn.com^
 ||e6s8k4m2.stackpathcdn.com^
+||e6yo1f2rs4mkh.novaspirit.casa^
 ||e7e9d8m4.stackpathcdn.com^
 ||e7g6h8h2.stackpathcdn.com^
 ||e7m2e2d5.stackpathcdn.com^
@@ -77403,6 +77456,7 @@
 ||edergroup-atg.at^
 ||edero.shop^
 ||edetykrsl.inpiq.biz^
+||edevelop.space^
 ||edgar.game.blog^
 ||edgar.water.blog^
 ||edgeoutline.site^
@@ -78313,6 +78367,7 @@
 ||ehrensache.jetzt^
 ||ehrlich-jetzt.wtf^
 ||ehs.sph.berkeley.edu^
+||eht435.chillj.com^
 ||ehty.com^
 ||ehuemoy.stripocdn.email^
 ||ehusbandry.lol^
@@ -82589,6 +82644,7 @@
 ||fgdbnvcxxcwfsdgrstrtessg.s3.amazonaws.com^
 ||fgdwwwstvg.duckdns.org^
 ||fgehen69.com^
+||fgf96.topbest.space^
 ||fgftrgdefgdvbcnbkmlopikhd.s3.amazonaws.com^
 ||fgh-409763500220.southamerica-east1.run.app^
 ||fgiaggi.r.af.d.sendibt2.com^
@@ -87884,6 +87940,7 @@
 ||glasvezelzuidenveld.nexxtcom.nl^
 ||glaube.jetzt^
 ||glave2.com^
+||glavinus.beer^
 ||glavionexura.com^
 ||glbhxf.edu^
 ||gldvite.com^
@@ -88565,6 +88622,7 @@
 ||gq086.lucksocialplay.com^
 ||gq889.tennisylives.com^
 ||gq917.tersan-do.com^
+||gqi56.myloves.space^
 ||gqiaoszzzi.com^
 ||gqjuy0yyfkvfbj8orhxb.s3.amazonaws.com^
 ||gqkuhcclaxdb.wwvpsa.top^
@@ -90838,6 +90896,7 @@
 ||hh.achesoncrow.com^
 ||hh.amaisd.org^
 ||hh284.spellbowl.com^
+||hh729.wisey.space^
 ||hh96.lucksocialplay.com^
 ||hhcf.org^
 ||hhcontentconnector.com^
@@ -91708,6 +91767,7 @@
 ||hillsborough.com.au^
 ||hillsidecabins.org^
 ||hillsidehigh.org^
+||hillsidenow.com^
 ||hillsletter.living^
 ||hilltopinnovations.net^
 ||hillvores.com^
@@ -93057,6 +93117,7 @@
 ||hvwclub.com^
 ||hvyitblog.world^
 ||hw310.golffasters.com^
+||hw71.wisey.space^
 ||hw81.spellbowl.com^
 ||hwaboutwe.com^
 ||hwangsung.kr^
@@ -93116,6 +93177,7 @@
 ||hygge-int.com^
 ||hygiene-forlife.com^
 ||hyibyf.com^
+||hymer-auswahlrunde.de^
 ||hymool.com^
 ||hympol.digital^
 ||hyo46.spellwicket.com^
@@ -93394,6 +93456,7 @@
 ||iawv3vg8.createsend1.com^
 ||ib.barclays^
 ||ib71.com^
+||ib970.edevelop.space^
 ||ibay.jetzt^
 ||ibb.co^
 ||ibbevplvrqrexlzeqr.porrwangsupport.shop^
@@ -94972,6 +95035,7 @@
 ||impatienssad.shop^
 ||imperatorcasino.me^
 ||imperfield.com^
+||imperiodized.com^
 ||imperium.wellbeingzone.co.uk^
 ||imperva.com^
 ||impf-dich.jetzt^
@@ -95415,6 +95479,7 @@
 ||inmobiliariarobinson.com^
 ||inmortalboost.com^
 ||inmotionhosting.com^
+||inmycorner.dev^
 ||inmyreview.health.blog^
 ||inn-hotels.east-kazakhstan.su^
 ||inn.roundhousexboxdrv.pw^
@@ -96347,6 +96412,7 @@
 ||item-m6.com^
 ||item202.com^
 ||itemboxpubgm.com^
+||itemdb.com^
 ||items-latest.uno^
 ||items-outlet.uno^
 ||itemsmembership.bond^
@@ -96804,6 +96870,7 @@
 ||jaelynjnhey.ru.com^
 ||jaelynnhotif.ru.com^
 ||jaelynzqhey.click^
+||jaf789.madeof.space^
 ||jagaplay.com^
 ||jagd.jetzt^
 ||jageleve.com^
@@ -97025,6 +97092,7 @@
 ||jbwilliams-jd.com^
 ||jbwzszy.com^
 ||jc-agent.com^
+||jc220.mytrex.space^
 ||jc26.mahjongplayworlds.com^
 ||jcal.tech.blog^
 ||jcb54.playtotriumph.com^
@@ -99373,6 +99441,7 @@
 ||jlwogl.buakvd.biz^
 ||jlzte.com^
 ||jm-service.se^
+||jm014.catholicbali.com^
 ||jm03.usersmp.com^
 ||jm0u2d6ev2.ilbdn.help^
 ||jm675.fastbreakpicks.com^
@@ -99883,6 +99952,7 @@
 ||jpg4xxx.pw^
 ||jpgaming88.com^
 ||jpgrooves.com^
+||jph07.gamewizen.com^
 ||jphvrgopmk.ufn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
 ||jpiswriting.com^
 ||jpjo.amu.edu.pl^
@@ -99910,6 +99980,7 @@
 ||jr045.smartmanch3.com^
 ||jr3rh13j.sega338.live^
 ||jr768.satinveil.com^
+||jr92.myrule.space^
 ||jradius.nl^
 ||jrc27.zen-flowh.com^
 ||jrcsps.com^
@@ -99976,6 +100047,7 @@
 ||ju07ygfee2nf4wkk.iriehub.com^
 ||ju570.faphouse3.com^
 ||ju71.skate-draft.com^
+||juachigranover.com^
 ||juahnpwrnh.ctn.gts.multisan.st.ap.gtr-dev.certsbridge.com^
 ||jualsajadah.sites.id^
 ||juanpaula145gmail.music.blog^
@@ -100384,6 +100456,7 @@
 ||ka.sexhan.top^
 ||ka.usa-casino-online.com^
 ||ka.xxxhdhindi.com^
+||ka14.playtotriumph.com^
 ||ka478.securitypjcts.com^
 ||ka502.zen-flowh.com^
 ||ka849.radrebelproject.com^
@@ -100486,6 +100559,8 @@
 ||kalsoer.web.app^
 ||kaltengnews.com^
 ||kaltschmid.org^
+||kalwl.accountcassette.com^
+||kalwl.affecthurl.com^
 ||kalwl.fathtanja.online^
 ||kalwl.mamujutengahkab.id^
 ||kalyonemlakgayrimenkul.com^
@@ -101292,6 +101367,7 @@
 ||kidsmonitoring.tdsclick.org^
 ||kidsquestsupport.egifter.com^
 ||kidswheelchairsexposed.activateforkids.co.uk^
+||kie69.cmpssc.com^
 ||kiehapoker.com^
 ||kiehapoker.haushalts-helfer.net^
 ||kiejy0wuxji.whitetoquescripts.com^
@@ -102433,6 +102509,7 @@
 ||klyyideiqv.ufn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
 ||km.pornxxxporn.com^
 ||km.usa-casino-online.com^
+||km773.mytrex.space^
 ||kmail-lists.com^
 ||kmarko.com^
 ||kmd15o1d10ra.glnaq.bar^
@@ -102532,6 +102609,7 @@
 ||ko13.victorypuck.com^
 ||ko14.getvariety.space^
 ||ko23.winningwickets.com^
+||ko67.nexoexpresses.com^
 ||ko7g0sdhuuq4is2jfcst.s3.amazonaws.com^
 ||ko8o10yny6.com^
 ||koacksm.com^
@@ -102971,6 +103049,8 @@
 ||kstreetstudios.thehill.com^
 ||ksvhessen.de^
 ||kswxc73s864.cleanvvglow.com^
+||ksxbg.accountcassette.com^
+||ksxbg.affecthurl.com^
 ||ksyhcy.com^
 ||kszuepwv.rezeptfreie-potenzmittel.info^
 ||kt1d.net^
@@ -103335,6 +103415,7 @@
 ||la365us.com^
 ||la449.fastbreaklegendspl.com^
 ||la641.yenreflyst.com^
+||la75.wisey.space^
 ||laaid.spokerewired.com^
 ||laajademo.noho.production.geniem.io^
 ||laakj.com^
@@ -104049,6 +104130,7 @@
 ||leatherjacket.bestdeal.sbs^
 ||leazint.de^
 ||leb.jetzt^
+||leb253.nexoexpresses.com^
 ||lebbyshers.com^
 ||lebe-dein-spirit.jetzt^
 ||lebe-deine-freiheit.jetzt^
@@ -104164,6 +104246,7 @@
 ||ledoutfitters.com^
 ||lee-brennholz.ch^
 ||lee652.revereldant.com^
+||lee9ytn4v0.inmycorner.dev^
 ||leeb.jetzt^
 ||leebankandtrust.com^
 ||leebler.sbs^
@@ -104559,6 +104642,7 @@
 ||lfvkj.com^
 ||lfw20webservice.merck-animal-health.com^
 ||lfyvrftjen.ufn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
+||lfz910.madeof.space^
 ||lg-npltf.com^
 ||lg.thelogicgroup.v4.pressero.com^
 ||lg30.golfykeep.com^
@@ -106150,6 +106234,7 @@
 ||lnx.bartolotta.info^
 ||lnysbxg.com^
 ||lo.usa-casino-online.com^
+||lo07.playtotriumph.com^
 ||lo23jetzt-ba.xyz^
 ||lo36.betstreamline.com^
 ||lo853.texticob.com^
@@ -107265,6 +107350,8 @@
 ||lust-auf-erfolg.jetzt^
 ||lustchat.com^
 ||lusthdsite.com^
+||lustich.de-index.info^
+||lustich.de^
 ||lustichfrau.life^
 ||lustifersexshop.mx^
 ||lustigesbdsm.com^
@@ -107949,6 +108036,7 @@
 ||madeleynaka.health.blog^
 ||madelinechuvalas.com^
 ||madelyndnpretty.info^
+||madeof.space^
 ||madhusabod9a.sport.blog^
 ||madiatop1sys.com^
 ||madisonandmaingallery.com^
@@ -109086,6 +109174,7 @@
 ||mail.looble.net^
 ||mail.look-you.one^
 ||mail.lookinonlinecasino.com^
+||mail.loonesryfs.com^
 ||mail.lootvoucher.com^
 ||mail.lotnightxx.fun^
 ||mail.love-you.one^
@@ -110762,6 +110851,7 @@
 ||markthompsonacutherapy.com^
 ||marktplaarts.nl^
 ||markuspipes.cz^
+||markwjohnson.org^
 ||marlazarateyafuerinos.com^
 ||marlboro-rust.ru^
 ||marlboroughsfc.com^
@@ -111345,6 +111435,7 @@
 ||mc13dy4v9z.novaspirit.casa^
 ||mc2-il2-pltfspk-psqlf-01.postgres.database.usgovcloudapi.net^
 ||mc2-il2-pltfspk-psqlf01.postgres.database.usgovcloudapi.net^
+||mc21.myrule.space^
 ||mc32.getnews.space^
 ||mc418.betstreamline.com^
 ||mc4free.pl^
@@ -112936,6 +113027,7 @@
 ||mkck.nl^
 ||mkdconsultancy.com^
 ||mkeeujyasz.crxert.bond^
+||mki335.nexoexpresses.com^
 ||mkindustries.co^
 ||mkleaks.net^
 ||mkm.ma^
@@ -113837,6 +113929,7 @@
 ||mocasino.co.uk^
 ||mocha.app^
 ||mochangtong.wenfeng123.cn^
+||mochis.tecnm.mx^
 ||mockingsoft.com^
 ||mockpoker.com^
 ||mockupkool.com^
@@ -114225,6 +114318,7 @@
 ||more-2-flirt.com^
 ||more-together.com^
 ||more.mynextplatform.com^
+||more2flirt.com^
 ||moreavailable.blog^
 ||morecoffee.com.au^
 ||morefish3.in^
@@ -114523,6 +114617,7 @@
 ||mp3zz.life^
 ||mp4.allesporno.net^
 ||mp4cage.com^
+||mp4jbnjph0.purevbe.top^
 ||mp4moviesz.guru^
 ||mp4moviez.live^
 ||mp620.sinofgames.com^
@@ -114791,6 +114886,7 @@
 ||mt923.namesless.space^
 ||mta-253-214-77.smtp-out.sparkpostmail.com^
 ||mta-70-62-115.sparkpostmail.com^
+||mta-as-path.itemdb.com^
 ||mta-sts.a.medikamenterezeptfrei.biz^
 ||mta-sts.analytics-demo.medikamenterezeptfrei.biz^
 ||mta-sts.antispam.medikamenterezeptfrei.biz^
@@ -115077,6 +115173,7 @@
 ||muton-shuba.nikolaisergeev.ru^
 ||muton-tut.nikolaisergeev.ru^
 ||mutpro.top^
+||mutsce.com^
 ||mutsfine.com^
 ||muttizettel.jetzt^
 ||mutualofomaha.com^
@@ -115107,6 +115204,7 @@
 ||mv2mf5askvfd2dz.tarllerdigitalmedellin.com^
 ||mv58.efastmatch.space^
 ||mv843.mahjongplayworlds.com^
+||mva95.gamewizen.com^
 ||mvbifn3i20kftwjolxnxemq79r9hl2.s3.us.cloud-object-storage.appdomain.cloud^
 ||mvcasino.uk^
 ||mvdesignconsultoria.com^
@@ -115180,6 +115278,7 @@
 ||mxk410.oneclawllc.com^
 ||mxn.co.kr^
 ||mxr05.usersmp.com^
+||mxr68.madeof.space^
 ||mxs-161255673571.southamerica-east1.run.app^
 ||mxs.medikamenterezeptfrei.biz^
 ||mxschool.edu^
@@ -115454,6 +115553,7 @@
 ||mylottotactics.com^
 ||mylovematchnow.com^
 ||myloves-mailing.xyz^
+||myloves.space^
 ||mylscbenefit.com^
 ||mylucidthoughts.blog^
 ||mymagic.pro^
@@ -115524,6 +115624,7 @@
 ||myringtonemixer.com^
 ||myritini.vip^
 ||myroka.com^
+||myrule.space^
 ||mysababuilder.com^
 ||mysanitaire.com^
 ||mysays.co^
@@ -115608,6 +115709,7 @@
 ||mytradequote.com.au^
 ||mytravels.water.blog^
 ||mytrelino.com^
+||mytrex.space^
 ||mytrking.com^
 ||mytuksa.vip^
 ||mytype.ink^
@@ -115745,6 +115847,7 @@
 ||n9y7w7k2.stackpathcdn.com^
 ||n9z8y4a2.stackpathcdn.com^
 ||na.unibetpoker.biz^
+||na3bribnu.olynatr-bet-velo3d-85.xyz^
 ||na4.docusign.net^
 ||na502.proplayguide.com^
 ||na515u7.pinphase-pin.com^
@@ -119251,6 +119354,8 @@
 ||ofairline.com^
 ||ofballs.com^
 ||ofbestreward.com^
+||ofbkl.accountcassette.com^
+||ofbkl.affecthurl.com^
 ||ofcacademy.com^
 ||ofek-lated.com^
 ||ofertasexpress.com.br^
@@ -119337,6 +119442,7 @@
 ||offshorepipeline.net^
 ||offthecourt.music.blog^
 ||offyrdwaxn.ctn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
+||ofh012.jashokin.com^
 ||ofhalf.com^
 ||ofhearing.com^
 ||ofi841.chillleague.com^
@@ -119852,6 +119958,8 @@
 ||olymphone.com^
 ||olympics2030.com^
 ||olympopizzas.com^
+||olynatr-bet-velo3d-85.xyz^
+||olynatr-gnomem5565-99.xyz^
 ||olz570.teracrafft.com^
 ||om100.thinksparkimpact.com^
 ||om330.tersan-do.com^
@@ -121443,6 +121551,7 @@
 ||ostsee-urlaub.jetzt^
 ||ostsee.jetzt^
 ||osuk-mail.com^
+||osz20.tenfas.com^
 ||osztaly-gyar.cam^
 ||ot034.odgersai.com^
 ||ot41.derentyls.com^
@@ -121730,6 +121839,8 @@
 ||owlette962796.umnexzastb.digital^
 ||owlllus.com^
 ||owlny.com^
+||owlos.accountcassette.com^
+||owlos.affecthurl.com^
 ||owlos.fathtanja.online^
 ||owlos.mamujutengahkab.id^
 ||owlsector.com^
@@ -123270,6 +123381,7 @@
 ||pg24.legendarens.com^
 ||pg474.savannah-directory.net^
 ||pg50.revereldant.com^
+||pg879.jashokin.com^
 ||pg999.prettyprofitsdaily.com^
 ||pgarrettclayton.com^
 ||pgasa.dp.ua^
@@ -123484,6 +123596,7 @@
 ||photo.g2bg.gay^
 ||photo.gb2f.gay^
 ||photobian.com^
+||photobooth.software^
 ||photographybyrossi.com^
 ||photojournalism.video^
 ||photopic.cyou^
@@ -123912,6 +124025,7 @@
 ||pj71.funplaych.com^
 ||pj85.egetalert.com^
 ||pje542.evice.space^
+||pje559.myrule.space^
 ||pjhkxsmdqo.ctn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
 ||pjjifxsykt.ufn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
 ||pjlfs.com^
@@ -125713,6 +125827,7 @@
 ||pp12.legendarens.com^
 ||pp21.winningwickets.com^
 ||pp416.puckmasterspl.com^
+||pp680.catholicbali.com^
 ||pp7ljwda0g.com^
 ||pp96.agenligabisa.com^
 ||pp987.jashokin.com^
@@ -126439,6 +126554,7 @@
 ||pr0jectxpr0j3ct.com^
 ||pr799.evice.space^
 ||pr9.network^
+||pr90.cmpssc.com^
 ||prabh-njt.com^
 ||prabhatca1.fashion.blog^
 ||practical-babbage-fe8826.netlify.app^
@@ -126772,6 +126888,7 @@
 ||princetonisd.com^
 ||principal-765775392619.southamerica-east1.run.app^
 ||principessagiramondoonline.com^
+||priney.space^
 ||prinksale.finance^
 ||prinksalon.com^
 ||prinsenstraat22.nl^
@@ -127499,6 +127616,7 @@
 ||pts724.fastbreakpicks.com^
 ||ptsaofranciscodobrejao.siganet.net.br^
 ||ptscasino.com^
+||ptx98.myloves.space^
 ||ptxkisuhsy.ctn.gts.multisan.st.ap.gtr-dev.certsbridge.com^
 ||pu26-dienst.de^
 ||pua405.lancelot38.com^
@@ -128112,6 +128230,7 @@
 ||qgpsext002.broadridge.com^
 ||qgsjoqg.brpgmxm.rest^
 ||qgsukbosvaprfyrhpliargmynbddaw.s3.us-south.cloud-object-storage.appdomain.cloud^
+||qgt12.playtotriumph.com^
 ||qgubplsslj.ctn.gts.multisan.pr.ap.gtr.certsbridge.com^
 ||qgvvsyfkda.com^
 ||qh792.betstreamline.com^
@@ -128182,6 +128301,7 @@
 ||ql05.nexoexpresses.com^
 ||ql626.fastbreakpicks.com^
 ||ql906.poomerigs.com^
+||ql955.playtotriumph.com^
 ||qlfytimap2.medikamenterezeptfrei.biz^
 ||qlfytwww.imap2.medikamenterezeptfrei.biz^
 ||qlindorvexypt.com^
@@ -129254,6 +129374,7 @@
 ||qvx418.usersmp.com^
 ||qvz.tauliasexstorey.pw^
 ||qw233.championdraft.com^
+||qw453.kasiobask.com^
 ||qw803.inspiro-net.com^
 ||qw97.lensamurai.com^
 ||qwaveshop.com^
@@ -129747,6 +129868,7 @@
 ||ratesrot.com^
 ||ratgeber.jetzt^
 ||rathbeaghfarmhouse.com^
+||ratheast.com^
 ||rating-casino-1.info^
 ||rating-casino-top2.win^
 ||rating-casino977.win^
@@ -130321,6 +130443,7 @@
 ||reg900jetzt-erha23.xyz^
 ||regain.us^
 ||regal-paletas-c552c2.netlify.app^
+||regalbars.co.uk^
 ||regarderle.co^
 ||regardinary.com^
 ||regayzanki.com^
@@ -130354,6 +130477,7 @@
 ||register.checkin2work.com^
 ||register.emailsp.com^
 ||register.flirtgranny.com^
+||register.fremdgehen-mail.com^
 ||register.gay^
 ||register.gosexpertiza.kz^
 ||register.ivalyu.live^
@@ -130391,6 +130515,7 @@
 ||rehma.tv^
 ||rehobothremarket.com^
 ||rehomeyourpets.co^
+||rei89.kasiobask.com^
 ||reiberei.jetzt^
 ||reich-mit-chatgpt.info^
 ||reichjetzt.nl^
@@ -131522,6 +131647,7 @@
 ||rfwxodvrtd.ctn.gts.multisan.st.ap.gtr-dev.certsbridge.com^
 ||rfy628.clarkekraemers.com^
 ||rfylcuqdax.ctn.gts.multisan.pr.ap.gtr.certsbridge.com^
+||rfysohf2gb.deepcalm.hair^
 ||rg1.therichlandgroup.net^
 ||rg363.syndeventsoul.com^
 ||rganfipa.tk^
@@ -131553,6 +131679,7 @@
 ||rgz00.egetalert.com^
 ||rh.premadz.com^
 ||rh71.spinattackin.com^
+||rh738.kasiobask.com^
 ||rha-magazine.com^
 ||rha.unc.edu^
 ||rheana.com^
@@ -131987,6 +132114,7 @@
 ||robinsonbipa.law.blog^
 ||robinsontyma.law.blog^
 ||robintrack.com^
+||robiograms.com^
 ||roblox-api.online^
 ||roblox.jetzt^
 ||roblox2007.com^
@@ -132309,6 +132437,7 @@
 ||router.serverporn.org^
 ||routerin.com^
 ||routernode.net^
+||routeslim-de.itemdb.com^
 ||routinely.pro^
 ||rovecize.com^
 ||rovnrfrkyt.ufn.gts.multisan.st.ap.gtr-dev.certsbridge.com^
@@ -132387,6 +132516,7 @@
 ||roxy.joyridecity.bike^
 ||roy2001journal.blogspot.com^
 ||royal-498860997205.us-south1.run.app^
+||royal-cloud-wi1qq.apitest-3ujr5vljnp.workers.dev^
 ||royal-forest-8ixm.workers.dev^
 ||royal-rain-be5e.teccaotaxlioo.workers.dev^
 ||royal-river-oknc.workers.dev^
@@ -133163,6 +133293,7 @@
 ||rsb.jetzt^
 ||rscic.cyou^
 ||rsclone.info^
+||rsd9arcdmr1.blogfreecookbook.com^
 ||rsdiamonds.com^
 ||rsdwqluvko.ctn.ssl.multi1.st.v2.gclb.gtr-dev.certsbridge.com^
 ||rsglab.com^
@@ -134428,6 +134559,7 @@
 ||sbiseclinea.com^
 ||sbiseclineh.com^
 ||sbjmxabxq.orayuh.biz^
+||sbm89.wisey.space^
 ||sbmassociates.org^
 ||sbn.supplybuyersnetwork.com^
 ||sbo69nfb.com^
@@ -135375,6 +135507,7 @@
 ||serenasfpretty.click^
 ||serendipitycafesc.com^
 ||serenicapelli.com^
+||serenity-mail.de^
 ||serenityconsults.com^
 ||serenitydreams.org^
 ||serenityprettymt.ru.com^
@@ -135582,6 +135715,8 @@
 ||severalpump.com^
 ||severeporno.com^
 ||severesexfilms.com^
+||sevki.accountcassette.com^
+||sevki.affecthurl.com^
 ||sevuerotic.com^
 ||sevwerotic.com^
 ||sew.biz.id^
@@ -137228,6 +137363,7 @@
 ||shloker.com^
 ||shlxh123.com^
 ||shmerwe.com^
+||shn82.myloves.space^
 ||shnlq.mssb.my.id^
 ||sho.amu.edu.pl^
 ||shoaib.music.blog^
@@ -138071,6 +138207,8 @@
 ||sketchup.jetzt^
 ||skflirt.pmsingblog.com^
 ||skglb.jetzt^
+||skglw.accountcassette.com^
+||skglw.affecthurl.com^
 ||skibidihotel.com^
 ||skifknives.us^
 ||skil.jetzt^
@@ -138395,6 +138533,7 @@
 ||slr37d5z0r.aeromind.garden^
 ||sls.captn.com.au^
 ||sls.vegas^
+||sls605.topbest.space^
 ||sls78.tiloomse.com^
 ||slsedu.bar^
 ||slunutqggm.ctn.https.multi1.pr.v2.gclb.gtr.certsbridge.com^
@@ -138472,6 +138611,7 @@
 ||smallygearnyc.com^
 ||smalpelcasosex.ga^
 ||smanager.ds^
+||smart-assets-io-3719.s3.amazonaws.com^
 ||smart-conversion.com^
 ||smart-recommend-fast-device.autos^
 ||smart-s-safety.com^
@@ -138757,9 +138897,12 @@
 ||smutnomeketpostslut.ml^
 ||smutty.solidcams.com^
 ||smwca.org.uk^
+||smx08.priney.space^
 ||smydawoodworking.com^
 ||smys.net^
 ||sn.usa-casino-online.com^
+||sn276.playcentrals.com^
+||sn96.jashokin.com^
 ||snack.jetzt^
 ||snacks2u.com^
 ||snackz.shop^
@@ -139384,6 +139527,8 @@
 ||sosexcavation.com^
 ||sosexy.ro^
 ||sosflorestadocamboata.meurio.org.br^
+||soslos.accountcassette.com^
+||soslos.affecthurl.com^
 ||sosorchester.com^
 ||sospermisapoints.com^
 ||sosreformas.com.br^
@@ -139969,6 +140114,7 @@
 ||specials-genial.site^
 ||specials.klickparts.com^
 ||specials.more-together.com^
+||specials.more2flirt.com^
 ||specials.ng-source.com^
 ||specials.together-more.com^
 ||specialsalediscounts.com^
@@ -143496,6 +143642,7 @@
 ||stg.testosteron-rezeptfrei-bestellen.de^
 ||stg02.wowdesk.jp^
 ||stg2selfadministration.abilityadvantage.thehartford.com^
+||stg708.kasiobask.com^
 ||stgabilityadvantagereports2.thehartford.com^
 ||stge.boxingkingg2.com^
 ||sthelenspk-p-nsw.compass.education^
@@ -146597,6 +146744,7 @@
 ||techandchill.io^
 ||techandherbs.com^
 ||techbazaar88.com^
+||techbazaronline.co.uk^
 ||techboss.co.zw^
 ||techbusinessmusic.com^
 ||techbusinesssmart.com^
@@ -147426,6 +147574,8 @@
 ||tg44.myscoutai.com^
 ||tg578.touchdownelitede.com^
 ||tg986.ofitams.com^
+||tgavi.accountcassette.com^
+||tgavi.affecthurl.com^
 ||tgbexrvnurplskbpxgathy.puckmasterspl.com^
 ||tge453.fastbreakpicks.com^
 ||tgelbdeich.com^
@@ -148263,6 +148413,7 @@
 ||thessential.org^
 ||thestagingserver.in^
 ||thestevenblochimageofdisabilitycharitabletrust.com^
+||thestitchingparlorinc.com^
 ||thestylique.com^
 ||thesuccesslane.car.blog^
 ||thesudokuprofesor.com^
@@ -148921,6 +149072,7 @@
 ||tl.usa-casino-online.com^
 ||tl.worldclassoffer.com^
 ||tl.wvu.edu^
+||tl19.topbest.space^
 ||tl3r92sd.cxtwczu.top^
 ||tl40.match3funs.com^
 ||tl46.championdraft.com^
@@ -149241,6 +149393,7 @@
 ||topazreads.com^
 ||topbbwporn.com^
 ||topbcsconvneedstracks.com^
+||topbest.space^
 ||topbestluckyxoffer.com^
 ||topbildung.jetzt^
 ||topbolsaschelita.com^
@@ -150091,6 +150244,7 @@
 ||tree.stcecyten.org^
 ||treeby.biz^
 ||treehouse-editing.com^
+||treehousefamilyadvisory.com^
 ||treesgrowsilently.com^
 ||treeshearingeastsussex.co.uk^
 ||treff.jetzt^
@@ -150495,6 +150649,7 @@
 ||ts.testosteron-rezeptfrei-bestellen.de^
 ||ts031.oneclawllc.com^
 ||ts22.nexoexpresses.com^
+||ts403.priney.space^
 ||ts75.victorypuck.com^
 ||ts880.texticob.com^
 ||tsaclit.com^
@@ -150514,6 +150669,7 @@
 ||tsonta.sextilefona.com^
 ||tsoroka.gb.net^
 ||tsotsarmemjet.pw^
+||tsp743.derentyls.com^
 ||tspk-botrasp.store^
 ||tspk-co.com^
 ||tspk-kungfu.com^
@@ -151703,6 +151859,7 @@
 ||twux.com^
 ||twv.car.blog^
 ||twweb.co.uk^
+||tx091.playcentrals.com^
 ||tx3s426cbxe13um8bx5l.s3.eu-west-1.amazonaws.com^
 ||tx493.sall0.com^
 ||txapartmentviewing.com^
@@ -151746,6 +151903,8 @@
 ||typicalsecuritydevice.com^
 ||typing.prosoftnet.org^
 ||typodata.com^
+||tyqsb.accountcassette.com^
+||tyqsb.affecthurl.com^
 ||tyrefitter.com.au^
 ||tyrone.thelittlesensory.co^
 ||tyrone1.thelittlesensory.co^
@@ -152010,6 +152169,7 @@
 ||ucywsr06na.pixelpinsup.com^
 ||ud168.fusionais.com^
 ||ud175.derentyls.com^
+||ud187.jashokin.com^
 ||ud911.funplaych.com^
 ||udasto.com^
 ||udb789.shirtsneeded.com^
@@ -152033,6 +152193,7 @@
 ||uebersetzer.jetzt^
 ||uedojwjdjo.ctn.gts.multisan.pr.ap.gtr.certsbridge.com^
 ||uegcxlzw.com^
+||ueh.edu.vn^
 ||uehacerahora.org^
 ||ueht.com^
 ||uemg.br^
@@ -152205,6 +152366,7 @@
 ||ukwtw.com^
 ||ul17.tennisshine.com^
 ||ul304.legendstrial.com^
+||ul974.jashokin.com^
 ||ulam.uno^
 ||ulandeyamanakaz28.science.blog^
 ||ulangaarderoxju.family.blog^
@@ -152574,6 +152736,7 @@
 ||unq504.playpeakin.com^
 ||unqz.deepcalm.hair^
 ||unrealestateibiza.com^
+||unrealsoft.bg^
 ||unreliable.org^
 ||unrivaled-strudel-bf2e6e.netlify.app^
 ||uns.ac.rs^
@@ -152595,6 +152758,7 @@
 ||unssector.com^
 ||unsubfromall.s3.us-west-1.amazonaws.com^
 ||unsubscribe.loudabbe.com^
+||unsubscribe.more2flirt.com^
 ||unsubscribe2.do^
 ||unsunkempt.com^
 ||unsymmetricanglophilia.life^
@@ -152748,6 +152912,7 @@
 ||upwork.com^
 ||upyield.io^
 ||uq10.betwisen.com^
+||uq17.tenfas.com^
 ||uq795.runewicket.com^
 ||uq842.etfcoin.cc^
 ||uqabb5qnhgaydyux.devices.modento.co^
@@ -152871,6 +153036,7 @@
 ||urv55.promanch3.com^
 ||urverifikation.dk^
 ||urvertrauen.jetzt^
+||ury65.nexoexpresses.com^
 ||uryfx.cyou^
 ||uryurys.shop^
 ||us-bitcoincasino.com^
@@ -152881,6 +153047,7 @@
 ||us.digitaldiary.app^
 ||us.khoros-mail.com^
 ||us.sagepub.com.bdigitaluss.remotexs.co^
+||us00.playtotriumph.com^
 ||us02.legendcups.com^
 ||us11.campaign-archive.com^
 ||us2rpsn67k.com^
@@ -154877,6 +155044,7 @@
 ||vestesblousonshomme.com^
 ||vestnic.com^
 ||vet-insurance.com^
+||vet.just.edu.jo^
 ||vetbiz.shop^
 ||veteranadvocacynetwork.com^
 ||veteranaspornos.cyou^
@@ -154963,6 +155131,7 @@
 ||vi547.equest.space^
 ||vi55.mahjongplayworlds.com^
 ||vi7fgf0526h.rbgnzoo.biz^
+||vi93.derentyls.com^
 ||vi93.roing-tab.com^
 ||via-varejo-ponto-online.plugins.skore.io^
 ||via.placeholder.com^
@@ -155716,6 +155885,7 @@
 ||vle.claverham.e-sussex.sch.uk^
 ||vlenkoty63.workers.dev^
 ||vlg.gay^
+||vll167.wisey.space^
 ||vlm.security-dealer.com^
 ||vln01.zahap.com^
 ||vlnnltwthv4.com^
@@ -156046,6 +156216,7 @@
 ||vpttechtamil.online^
 ||vpuxtxzawa.duckdns.org^
 ||vq786.victorypuck.com^
+||vqb72.wisey.space^
 ||vqboireump.ctn.https.multi1.pr.v2.gclb.gtr.certsbridge.com^
 ||vqlxdvbhqa.ctn.ssl.multi1.st.v2.gclb.gtr-dev.certsbridge.com^
 ||vqn.match3zone.com^
@@ -156069,6 +156240,7 @@
 ||vr-jahrenjetzt-23.online^
 ||vr-jarehrejetzt23.online^
 ||vr-meinservice.com^
+||vr-online-konto-aktualisierung.cfd^
 ||vr-spk-connect.digital^
 ||vr.adulthdvideo.com^
 ||vr.cams.livesex18.cam^
@@ -156993,6 +157165,7 @@
 ||vzhouse.com^
 ||vzknx3eegpzxyvr.mail.568vdcasino.com^
 ||vztz.shop^
+||vzv18.priney.space^
 ||w-1952.bbwfriendship.com^
 ||w-5820.yoloonsapp.com^
 ||w-9749.spacetimenav.com^
@@ -160127,6 +160300,7 @@
 ||willow.laouslyneuromalakia.digital^
 ||willow4424100.dexzsabib.digital^
 ||willowfarmcampgroundpa.com^
+||willowhousing.org.uk^
 ||willowmeethk.ru.com^
 ||willowriverphotography.com^
 ||willowspringscabins.com^
@@ -160402,6 +160576,7 @@
 ||wiseowlsbest.com^
 ||wiseplatter.co^
 ||wiseridgecb.name^
+||wisey.space^
 ||wishflex.info^
 ||wishingyoufirst.online^
 ||wishpond.hu.net^
@@ -160889,6 +161064,7 @@
 ||wpprojects.iiasa.ac.at^
 ||wpt349.shirtsneeded.com^
 ||wptest.iiasa.ac.at^
+||wpy95.derentyls.com^
 ||wq077.depsimovi.com^
 ||wq465.mytholeague.com^
 ||wq9ww.o-times.com^
@@ -160990,6 +161166,7 @@
 ||wsnhdarz.oevlq.forum^
 ||wsocial.eu^
 ||wsportskorea.com^
+||wsr70.topbest.space^
 ||wss.co.zw^
 ||wss.demo.aliens-and-fruits.ruvibet.com^
 ||wss.demo.aymara.ruvibet.com^
@@ -161452,6 +161629,7 @@
 ||www.flowiseai.medikamenterezeptfrei.biz^
 ||www.fna.testosteron-rezeptfrei-bestellen.de^
 ||www.forums.levitrarezeptfrei.de^
+||www.fremdgehen-mail.com^
 ||www.ftp.kamagra-rezeptfrei.site^
 ||www.ftp.medikamenterezeptfrei.biz^
 ||www.fxqzlcma.testosteron-rezeptfrei-bestellen.de^
@@ -161566,6 +161744,7 @@
 ||www.mobile.medikamenterezeptfrei.biz^
 ||www.modafinilrezeptfrei.space^
 ||www.mongo.testosteron-rezeptfrei-bestellen.de^
+||www.more2flirt.com^
 ||www.ms.medikamenterezeptfrei.biz^
 ||www.ms1.medikamenterezeptfrei.biz^
 ||www.mta-sts.medikamenterezeptfrei.biz^
@@ -162968,6 +163147,7 @@
 ||xc05.e-tipos.com^
 ||xc21.chillleague.com^
 ||xc28x7s.ilbdn.help^
+||xc564.playtotriumph.com^
 ||xc74.smartmanch3.com^
 ||xca699.sinofgames.com^
 ||xcamslive.solidcams.com^
@@ -163127,6 +163307,7 @@
 ||xhfiffsism.ufn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
 ||xhghxiqqql.ctn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
 ||xhgzyck.com^
+||xhh971.chillj.com^
 ||xhhlhh.com^
 ||xhotmaxporno.xyz^
 ||xhotpornx.xyz^
@@ -163197,6 +163378,7 @@
 ||xk22.kasiobask.com^
 ||xk393.boulindas.com^
 ||xk90.funplaych.com^
+||xkcu6lywzuu7jxb.hillsidenow.com^
 ||xkfruixgbv.ufn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
 ||xko54.stormkick.com^
 ||xkoream.cam^
@@ -163481,6 +163663,7 @@
 ||xt.hnlens.xyz^
 ||xt22.ematchlife.com^
 ||xt32.betwisen.com^
+||xt88.edevelop.space^
 ||xt9f4otx.com^
 ||xtape.to^
 ||xtcayyhuci.ctn.gts.multisan.st.ap.gtr-dev.certsbridge.com^
@@ -163502,6 +163685,7 @@
 ||xtremegreen.co^
 ||xtrim-it.com^
 ||xts5000olomo.pw^
+||xtt210.cmpssc.com^
 ||xttv.at^
 ||xtubepornmax.xyz^
 ||xtx37.milaydiin.com^
@@ -164746,6 +164930,7 @@
 ||ya78.revibesocialclub.com^
 ||ya79.newpairnow.com^
 ||ya887.hoopsdominance.com^
+||yaa64.cmpssc.com^
 ||yabalegynobeq.digital^
 ||yabarana.com^
 ||yabazam.com^
@@ -165172,6 +165357,7 @@
 ||yiutiub.to^
 ||yix587.mytholeague.com^
 ||yixiudn.com^
+||yj204.catholicbali.com^
 ||yj25.thinksparkgrowth.com^
 ||yj30.tenriun.com^
 ||yj51.golffasters.com^
@@ -165212,6 +165398,7 @@
 ||ykx95.tiloomse.com^
 ||ykygxr.bar^
 ||yl625.evice.space^
+||yl92.mytrex.space^
 ||ylmp2023.amu.edu.pl^
 ||ylohfprrqq.ufn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
 ||ylopssseconding.digital^
@@ -165620,6 +165807,7 @@
 ||yry776.ethosleaderhipcollective.com^
 ||ys-starhills.com^
 ||ys13.tennisshine.com^
+||ys147.nexoexpresses.com^
 ||ys161.ecandy.space^
 ||ys61.topin-game.com^
 ||ysadmin.modafinilrezeptfrei.space^
@@ -165766,6 +165954,7 @@
 ||ywkusyy.arfhd.help^
 ||ywocxxxxkq.sub1.ccm-breakit.certsbridge.com^
 ||ywopigmhow.ufn.gts.multisan.ap.ap.gtr-dev.certsbridge.com^
+||ywu331.myrule.space^
 ||ywv741.getmynew.space^
 ||yx140akai.fun^
 ||yx38.jashokin.com^
@@ -167098,6 +167287,7 @@
 ||ziidhqimow45l0r.www.store.pornsub.xyz^
 ||ziisuanpro.car.blog^
 ||zij-schot.fun^
+||zij588.topbest.space^
 ||zil.co.zw^
 ||zilch-uk.com^
 ||zilch-uk.only-jesus-saves.com^
@@ -167203,6 +167393,7 @@
 ||zk-bridge.network^
 ||zk080.topskillplay.com^
 ||zk2mv5base.com^
+||zk365.topbest.space^
 ||zk714.fastbreakpicks.com^
 ||zkassociatesonline.com^
 ||zkbgrd.bar^
@@ -167267,6 +167458,7 @@
 ||zntecymchdv8hfn.bar^
 ||znvrno.com^
 ||znxalaqnlho0o.bar^
+||zo08.edevelop.space^
 ||zo3bvkzvihk6.funplayclicks.com^
 ||zo855.baskfaon.com^
 ||zo88.baskionik.com^
@@ -167543,6 +167735,7 @@
 ||zt-vremya-dengi.fun^
 ||zt00.tersan-do.com^
 ||zt055.stormkick.com^
+||zt174.topbest.space^
 ||zt401.vionursets.com^
 ||zt60.senerivels.com^
 ||zt668.dream-resort.com^
@@ -167679,6 +167872,7 @@
 ||zx63.astralholistics.com^
 ||zxc4.buzz^
 ||zxg256.norplaysgame.com^
+||zxg636.catholicbali.com^
 ||zxo05.msevenelectronics.com^
 ||zxrabbit.com^
 ||zxvcwfds.fun^
@@ -167708,6 +167902,7 @@
 ||zyw.cam^
 ||zyy3097.xyz^
 ||zyz.cam^
+||zz06.playtotriumph.com^
 ||zz40.usersmp.com^
 ||zzb14.shadowsleague.com^
 ||zzeymq.biz^
@@ -167719,6 +167914,7 @@
 ||zzr474.fusionais.com^
 ||zzrqkbtxne.pixbvw.cfd^
 ||zzs350.sall0.com^
+||zzu690.gamewizen.com^
 ||zzu934.odpny.com^
 ||zzvdkf.bar^
 ||zzwenqing.com^


### PR DESCRIPTION
Adds the reported spam and phishing domains to the corresponding blocklists.

**Changes**
- `Blocklisten/spam.mails`: +196 domains from issue #2509
- `Blocklisten/Phishing-Angriffe`: +10 domains from issue #2510

**Details**
- Entries use the repository's ABP format (`||domain^`), inserted at the correct alphabetical position, line endings (CRLF) preserved.
- No existing lines were modified (206 insertions, 0 deletions).
- 3 duplicates already present in `spam.mails` were skipped (`artistioggi.org`, `virtuarters.com`, `vdartinc.com`); `vdartinc.com` is still added to `Phishing-Angriffe` per issue #2510.
- Domains were normalized to lowercase for consistency (e.g. `Hymer-auswahlrunde.de`, `Lustich.de-index.info`).
- Verified: no internal duplicates, all 206 new entries present exactly once.

Fixes #2509
Fixes #2510

---
*PR erstellt von einem automatisierten Agent (AincradBot). Inhalt geprüft gegen die Angaben in den Issues; die fachliche Freigabe der Domains liegt beim Repo-Maintainer.*
